### PR TITLE
Rename InhibitoryFact to NegationFact and clarify neuroscience claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ uv run pre-commit run --all-files
 | Fact | Pattern-extracted facts (emails, phones, dates) | 0.9 (extracted) |
 | SemanticMemory | LLM-inferred knowledge | 0.6 (inferred) |
 | ProceduralMemory | Behavioral patterns | 0.6 (inferred) |
-| InhibitoryFact | What is NOT true (negations) | 0.7 (inferred) |
+| NegationFact | What is NOT true (negations) | 0.7 (inferred) |
 
 ### Confidence Scoring
 
@@ -271,7 +271,9 @@ consolidation_agent = Agent(
 The six memory types are engineering constructs:
 - **Working, Episodic, Semantic, Procedural** — Inspired by cognitive science
 - **Factual** — Engineering subdivision (verbatim vs inferred) not from cognitive science
-- **Inhibitory** — Inspired by CCK+ interneurons in memory selectivity (Tomé et al.)
+- **Negation** — Engineering construct for storing semantic negations (what is NOT true)
+
+The `selectivity_score` on SemanticMemory is the genuine connection to Tomé et al. research on dynamic engrams and inhibitory plasticity.
 
 Be explicit about which are science-inspired and which are engineering additions.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ flowchart LR
         FACT{{📊 FACTUAL}}
         SEM([💡 SEMANTIC])
         PROC([⚙️ PROCEDURAL])
-        INH([🚫 INHIBITORY])
+        NEG([🚫 NEGATION])
     end
 
     subgraph STORE [" "]
@@ -82,7 +82,7 @@ flowchart LR
 
     WM ==>|encode| EP
     EP -->|extract| FACT
-    EP -->|negate| INH
+    EP -->|negate| NEG
     EP -->|consolidate| SEM
     EP -->|pattern| PROC
 
@@ -90,14 +90,14 @@ flowchart LR
     FACT -.->|store| QD
     SEM -.->|store| QD
     PROC -.->|store| QD
-    INH -.->|store| QD
+    NEG -.->|store| QD
 
     style WM fill:#fbbf24,stroke:#b45309,stroke-width:3px,color:#1c1917
     style EP fill:#a78bfa,stroke:#7c3aed,stroke-width:3px,color:#1c1917
     style FACT fill:#60a5fa,stroke:#2563eb,stroke-width:3px,color:#1c1917
     style SEM fill:#34d399,stroke:#059669,stroke-width:3px,color:#1c1917
     style PROC fill:#f472b6,stroke:#db2777,stroke-width:3px,color:#1c1917
-    style INH fill:#f87171,stroke:#dc2626,stroke-width:3px,color:#1c1917
+    style NEG fill:#f87171,stroke:#dc2626,stroke-width:3px,color:#1c1917
     style QD fill:#fb923c,stroke:#c2410c,stroke-width:3px,color:#1c1917
 
     style INPUT fill:transparent,stroke:#fbbf24,stroke-width:2px,stroke-dasharray:5
@@ -112,7 +112,7 @@ flowchart LR
 | **Factual** | High | Pattern extraction | Emails, dates, names |
 | **Semantic** | Variable | LLM inference | Preferences, context |
 | **Procedural** | Variable | LLM inference | Behavioral preferences |
-| **Inhibitory** | Variable | Negation detection | What is NOT true |
+| **Negation** | Variable | Negation detection | What is NOT true |
 
 ## Preventing Hallucinations
 

--- a/research/competitive.md
+++ b/research/competitive.md
@@ -169,7 +169,9 @@ Novel approaches from recent literature:
 - Inhibitory plasticity (CCK+ interneurons) is critical for selectivity
 - Training stimulus reactivation during consolidation required for selectivity to emerge
 
-**Engram**: Implements `selectivity_score` (0.0-1.0) that increases during consolidation passes, and `InhibitoryFact` memory type that tracks what is explicitly NOT true (e.g., "User does NOT use MongoDB").
+**Engram**: The `selectivity_score` (0.0-1.0) on SemanticMemory is directly inspired by this research—it increases as memories survive consolidation passes, modeling how engrams become more selective over time.
+
+Note: `NegationFact` (which stores semantic negations like "User does NOT use MongoDB") is a separate engineering construct, not an implementation of neural inhibition.
 
 ---
 

--- a/research/overview.md
+++ b/research/overview.md
@@ -6,7 +6,7 @@ This document explains *why* Engram makes its specific design choices, with cita
 
 ### 1. Multiple Memory Types
 
-**Design**: Engram maintains six distinct memory types (working, episodic, factual, semantic, procedural, inhibitory) rather than a single undifferentiated store.
+**Design**: Engram maintains six distinct memory types (working, episodic, factual, semantic, procedural, negation) rather than a single undifferentiated store.
 
 **Research basis**:
 
@@ -194,4 +194,4 @@ We use cognitive science as design inspiration, not strict implementation. These
 - [Adaptive Compression Framework](https://www.nature.com/articles/s44159-025-00458-6) — Memory as compression under constraints
 - [Dual Pathways to LTM](https://www.news-medical.net/news/20241206/Researchers-discover-new-pathway-to-forming-long-term-memories-in-the-brain.aspx) — LTM can form independently of STM
 - [Molecular Memory Timers](https://www.sciencedaily.com/releases/2025/11/251130050712.htm) — Importance gating in memory persistence
-- [Dynamic and Selective Engrams](https://www.nature.com/articles/s41593-023-01551-w) — Tomé et al., Nature Neuroscience 2024: Memory engrams are dynamic (neurons drop in/out during consolidation) and become selective over time via inhibitory plasticity
+- [Dynamic and Selective Engrams](https://www.nature.com/articles/s41593-023-01551-w) — Tomé et al., Nature Neuroscience 2024: Memory engrams are dynamic (neurons drop in/out during consolidation) and become selective over time via inhibitory plasticity. Engram's `selectivity_score` is directly inspired by this finding.

--- a/src/engram/__init__.py
+++ b/src/engram/__init__.py
@@ -25,7 +25,7 @@ Memory Types:
     - Fact: Pattern-extracted facts (emails, phones, dates)
     - SemanticMemory: LLM-inferred knowledge
     - ProceduralMemory: Behavioral patterns
-    - InhibitoryFact: What is NOT true (negations)
+    - NegationFact: What is NOT true (negations)
     - Working: Current session context (in-memory)
 
 For more information, see: https://github.com/ashita-ai/engram
@@ -43,7 +43,7 @@ from .models import (
     Episode,
     ExtractionMethod,
     Fact,
-    InhibitoryFact,
+    NegationFact,
     ProceduralMemory,
     SemanticMemory,
 )
@@ -62,6 +62,6 @@ __all__ = [
     "Fact",
     "SemanticMemory",
     "ProceduralMemory",
-    "InhibitoryFact",
+    "NegationFact",
     "AuditEntry",
 ]

--- a/src/engram/api/router.py
+++ b/src/engram/api/router.py
@@ -287,7 +287,7 @@ async def get_memory_stats(
                 facts=stats.facts,
                 semantic=stats.semantic,
                 procedural=stats.procedural,
-                inhibitory=stats.inhibitory,
+                negation=stats.negation,
             ),
             confidence=ConfidenceStats(
                 facts_avg=stats.facts_avg_confidence,
@@ -364,13 +364,13 @@ async def get_sources(
 ) -> SourcesResponse:
     """Get source episodes for a derived memory.
 
-    Traces a derived memory (fact, semantic, procedural, or inhibitory)
+    Traces a derived memory (fact, semantic, procedural, or negation)
     back to the source episode(s) it was extracted from. This enables
     provenance tracking and allows users to verify the origin of any
     derived knowledge.
 
     Args:
-        memory_id: ID of the derived memory (must start with fact_, sem_, proc_, or inh_).
+        memory_id: ID of the derived memory (must start with fact_, sem_, proc_, or neg_).
         user_id: User ID for multi-tenancy isolation.
         service: Injected EngramService.
 
@@ -388,13 +388,13 @@ async def get_sources(
         memory_type = "semantic"
     elif memory_id.startswith("proc_"):
         memory_type = "procedural"
-    elif memory_id.startswith("inh_"):
-        memory_type = "inhibitory"
+    elif memory_id.startswith("neg_"):
+        memory_type = "negation"
     else:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid memory ID format: {memory_id}. "
-            "Expected prefix: fact_, sem_, proc_, or inh_",
+            "Expected prefix: fact_, sem_, proc_, or neg_",
         )
 
     try:
@@ -442,13 +442,13 @@ async def verify_memory(
 ) -> VerificationResponse:
     """Verify a memory against its source episodes.
 
-    Traces a derived memory (fact, semantic, procedural, or inhibitory)
+    Traces a derived memory (fact, semantic, procedural, or negation)
     back to its source episode(s) and provides a human-readable explanation
     of how it was derived. This is core to Engram's "memory you can trust"
     value proposition.
 
     Args:
-        memory_id: ID of the derived memory (must start with fact_, sem_, proc_, or inh_).
+        memory_id: ID of the derived memory (must start with fact_, sem_, proc_, or neg_).
         user_id: User ID for multi-tenancy isolation.
         service: Injected EngramService.
 
@@ -482,7 +482,7 @@ async def verify_memory(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid memory ID format: {memory_id}. "
-            "Expected prefix: fact_, sem_, proc_, or inh_",
+            "Expected prefix: fact_, sem_, proc_, or neg_",
         )
 
     try:

--- a/src/engram/api/schemas.py
+++ b/src/engram/api/schemas.py
@@ -241,7 +241,7 @@ class MemoryCounts(BaseModel):
         facts: Number of extracted facts.
         semantic: Number of semantic memories (from consolidation).
         procedural: Number of procedural memories.
-        inhibitory: Number of inhibitory facts.
+        negation: Number of negation facts.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -250,7 +250,7 @@ class MemoryCounts(BaseModel):
     facts: int = Field(ge=0)
     semantic: int = Field(ge=0)
     procedural: int = Field(ge=0)
-    inhibitory: int = Field(ge=0)
+    negation: int = Field(ge=0)
 
 
 class ConfidenceStats(BaseModel):
@@ -315,11 +315,11 @@ class SourcesResponse(BaseModel):
     """Response for get_sources endpoint.
 
     Returns the source episodes that a derived memory (fact, semantic,
-    procedural, inhibitory) was extracted from.
+    procedural, negation) was extracted from.
 
     Attributes:
         memory_id: The ID of the derived memory.
-        memory_type: Type of memory (fact, semantic, procedural, inhibitory).
+        memory_type: Type of memory (fact, semantic, procedural, negation).
         sources: Source episodes in chronological order.
         count: Number of source episodes.
     """
@@ -370,7 +370,7 @@ class VerificationResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     memory_id: str = Field(description="ID of the verified memory")
-    memory_type: str = Field(description="Type: fact, semantic, procedural, inhibitory")
+    memory_type: str = Field(description="Type: fact, semantic, procedural, negation")
     content: str = Field(description="The memory content")
     verified: bool = Field(description="True if sources found and traceable")
     source_episodes: list[SourceEpisodeDetail] = Field(

--- a/src/engram/models/__init__.py
+++ b/src/engram/models/__init__.py
@@ -7,7 +7,7 @@ Memory Types:
     - Fact: Deterministically extracted facts
     - SemanticMemory: LLM-inferred knowledge
     - ProceduralMemory: Behavioral patterns
-    - InhibitoryFact: What is NOT true
+    - NegationFact: What is NOT true
 
 Supporting Types:
     - ConfidenceScore: Composite confidence with auditability
@@ -19,7 +19,7 @@ from .audit import AuditEntry
 from .base import ConfidenceScore, ExtractionMethod, MemoryBase, Staleness, generate_id
 from .episode import Episode
 from .fact import Fact
-from .inhibitory import InhibitoryFact
+from .negation import NegationFact
 from .procedural import ProceduralMemory
 from .semantic import SemanticMemory
 
@@ -35,7 +35,7 @@ __all__ = [
     "Fact",
     "SemanticMemory",
     "ProceduralMemory",
-    "InhibitoryFact",
+    "NegationFact",
     # Audit
     "AuditEntry",
 ]

--- a/src/engram/models/negation.py
+++ b/src/engram/models/negation.py
@@ -1,4 +1,4 @@
-"""InhibitoryFact model - tracking what is NOT true."""
+"""NegationFact model - tracking what is NOT true."""
 
 from datetime import UTC, datetime
 
@@ -7,15 +7,15 @@ from pydantic import Field
 from .base import ConfidenceScore, MemoryBase, generate_id
 
 
-class InhibitoryFact(MemoryBase):
-    """Inhibitory memory - tracking what is explicitly NOT true.
+class NegationFact(MemoryBase):
+    """Negation memory - tracking what is explicitly NOT true.
 
-    Inhibitory facts prevent false matches by recording negations.
+    NegationFacts prevent false matches by recording explicit negations.
     When a user corrects a misunderstanding or explicitly negates
     something, we store that negation to filter future retrievals.
 
-    Inspired by the role of CCK+ interneurons in memory selectivity
-    (Tomé et al., Nature Neuroscience 2024).
+    This is an engineering construct for storing semantic negations,
+    not an implementation of neural inhibition mechanisms.
 
     Examples:
     - "User does NOT use MongoDB"
@@ -24,15 +24,15 @@ class InhibitoryFact(MemoryBase):
 
     Attributes:
         content: The negation statement.
-        negates_pattern: Pattern/keyword this inhibits in retrieval.
+        negates_pattern: Pattern/keyword this negates in retrieval.
         source_episode_ids: Episodes where negation was stated.
         derived_at: When we identified this negation.
         confidence: Composite confidence score.
     """
 
-    id: str = Field(default_factory=lambda: generate_id("inh"))
+    id: str = Field(default_factory=lambda: generate_id("neg"))
     content: str = Field(description="The negation statement")
-    negates_pattern: str = Field(description="Pattern or keyword this inhibits in retrieval")
+    negates_pattern: str = Field(description="Pattern or keyword this negates in retrieval")
     source_episode_ids: list[str] = Field(
         default_factory=list,
         description="Episodes where this negation was stated",
@@ -48,4 +48,4 @@ class InhibitoryFact(MemoryBase):
 
     def __str__(self) -> str:
         """String representation showing negation content."""
-        return f"InhibitoryFact({self.content})"
+        return f"NegationFact({self.content})"

--- a/src/engram/service.py
+++ b/src/engram/service.py
@@ -137,7 +137,7 @@ class VerificationResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     memory_id: str = Field(description="ID of the verified memory")
-    memory_type: str = Field(description="Type: fact, semantic, procedural, inhibitory")
+    memory_type: str = Field(description="Type: fact, semantic, procedural, negation")
     content: str = Field(description="The memory content")
     verified: bool = Field(description="True if sources found and traceable")
     source_episodes: list[dict[str, Any]] = Field(
@@ -688,7 +688,7 @@ class EngramService:
         """Get source episodes for a derived memory.
 
         Traces a derived memory (Fact, SemanticMemory, ProceduralMemory,
-        InhibitoryFact) back to its source Episode(s).
+        NegationFact) back to its source Episode(s).
 
         Args:
             memory_id: ID of the derived memory.
@@ -732,16 +732,16 @@ class EngramService:
                 raise KeyError(f"ProceduralMemory not found: {memory_id}")
             source_episode_ids = procedural.source_episode_ids
 
-        elif memory_id.startswith("inh_"):
-            inhibitory = await self.storage.get_inhibitory(memory_id, user_id)
-            if inhibitory is None:
-                raise KeyError(f"InhibitoryFact not found: {memory_id}")
-            source_episode_ids = inhibitory.source_episode_ids
+        elif memory_id.startswith("neg_"):
+            negation = await self.storage.get_negation(memory_id, user_id)
+            if negation is None:
+                raise KeyError(f"NegationFact not found: {memory_id}")
+            source_episode_ids = negation.source_episode_ids
 
         else:
             raise ValueError(
                 f"Cannot determine memory type from ID: {memory_id}. "
-                "Expected prefix: fact_, sem_, proc_, or inh_"
+                "Expected prefix: fact_, sem_, proc_, or neg_"
             )
 
         # Fetch source episodes
@@ -823,18 +823,18 @@ class EngramService:
             content = procedural.content
             confidence = procedural.confidence
 
-        elif memory_id.startswith("inh_"):
-            memory_type = "inhibitory"
-            inhibitory = await self.storage.get_inhibitory(memory_id, user_id)
-            if inhibitory is None:
-                raise KeyError(f"InhibitoryFact not found: {memory_id}")
-            content = inhibitory.content
-            confidence = inhibitory.confidence
+        elif memory_id.startswith("neg_"):
+            memory_type = "negation"
+            negation = await self.storage.get_negation(memory_id, user_id)
+            if negation is None:
+                raise KeyError(f"NegationFact not found: {memory_id}")
+            content = negation.content
+            confidence = negation.confidence
 
         else:
             raise ValueError(
                 f"Cannot determine memory type from ID: {memory_id}. "
-                "Expected prefix: fact_, sem_, proc_, or inh_"
+                "Expected prefix: fact_, sem_, proc_, or neg_"
             )
 
         # Get source episodes

--- a/src/engram/storage/base.py
+++ b/src/engram/storage/base.py
@@ -16,7 +16,7 @@ from engram.models import (
     AuditEntry,
     Episode,
     Fact,
-    InhibitoryFact,
+    NegationFact,
     ProceduralMemory,
     SemanticMemory,
 )
@@ -31,7 +31,7 @@ MemoryT = TypeVar(
     Fact,
     SemanticMemory,
     ProceduralMemory,
-    InhibitoryFact,
+    NegationFact,
     AuditEntry,
 )
 
@@ -41,7 +41,7 @@ COLLECTION_NAMES = {
     "fact": "factual",
     "semantic": "semantic",
     "procedural": "procedural",
-    "inhibitory": "inhibitory",
+    "negation": "negation",
     "audit": "audit",
 }
 

--- a/src/engram/storage/client.py
+++ b/src/engram/storage/client.py
@@ -38,7 +38,7 @@ class MemoryStats(BaseModel):
     facts: int = Field(default=0, ge=0, description="Number of extracted facts")
     semantic: int = Field(default=0, ge=0, description="Number of semantic memories")
     procedural: int = Field(default=0, ge=0, description="Number of procedural memories")
-    inhibitory: int = Field(default=0, ge=0, description="Number of inhibitory facts")
+    negation: int = Field(default=0, ge=0, description="Number of negation facts")
     pending_consolidation: int = Field(
         default=0, ge=0, description="Episodes awaiting consolidation"
     )
@@ -151,7 +151,7 @@ class EngramStorage(StoreMixin, SearchMixin, CRUDMixin, AuditMixin, StorageBase)
         facts_count = await count_collection("factual")
         semantic_count = await count_collection("semantic")
         procedural_count = await count_collection("procedural")
-        inhibitory_count = await count_collection("inhibitory")
+        negation_count = await count_collection("negation")
 
         # Count pending consolidation (unconsolidated episodes)
         unconsolidated_filter = models.Filter(
@@ -214,7 +214,7 @@ class EngramStorage(StoreMixin, SearchMixin, CRUDMixin, AuditMixin, StorageBase)
             facts=facts_count,
             semantic=semantic_count,
             procedural=procedural_count,
-            inhibitory=inhibitory_count,
+            negation=negation_count,
             pending_consolidation=pending_count,
             facts_avg_confidence=facts_avg,
             facts_min_confidence=facts_min,

--- a/src/engram/storage/crud.py
+++ b/src/engram/storage/crud.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
         AuditEntry,
         Episode,
         Fact,
-        InhibitoryFact,
+        NegationFact,
         ProceduralMemory,
         SemanticMemory,
     )
@@ -25,7 +25,7 @@ MemoryT = TypeVar(
     "Fact",
     "SemanticMemory",
     "ProceduralMemory",
-    "InhibitoryFact",
+    "NegationFact",
     "AuditEntry",
 )
 
@@ -77,11 +77,11 @@ class CRUDMixin:
 
         return await self._get_by_id(memory_id, user_id, "procedural", ProceduralMemory)
 
-    async def get_inhibitory(self, fact_id: str, user_id: str) -> InhibitoryFact | None:
-        """Get an inhibitory fact by ID."""
-        from engram.models import InhibitoryFact
+    async def get_negation(self, fact_id: str, user_id: str) -> NegationFact | None:
+        """Get a negation fact by ID."""
+        from engram.models import NegationFact
 
-        return await self._get_by_id(fact_id, user_id, "inhibitory", InhibitoryFact)
+        return await self._get_by_id(fact_id, user_id, "negation", NegationFact)
 
     async def _get_by_id(
         self,
@@ -152,9 +152,9 @@ class CRUDMixin:
         """Delete a procedural memory."""
         return await self._delete_by_id(memory_id, user_id, "procedural")
 
-    async def delete_inhibitory(self, fact_id: str, user_id: str) -> bool:
-        """Delete an inhibitory fact."""
-        return await self._delete_by_id(fact_id, user_id, "inhibitory")
+    async def delete_negation(self, fact_id: str, user_id: str) -> bool:
+        """Delete a negation fact."""
+        return await self._delete_by_id(fact_id, user_id, "negation")
 
     async def _delete_by_id(
         self,

--- a/src/engram/storage/search.py
+++ b/src/engram/storage/search.py
@@ -14,7 +14,7 @@ from qdrant_client import models
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from engram.models import Episode, Fact, InhibitoryFact, ProceduralMemory, SemanticMemory
+    from engram.models import Episode, Fact, NegationFact, ProceduralMemory, SemanticMemory
 
 MemoryT = TypeVar("MemoryT")
 
@@ -234,14 +234,14 @@ class SearchMixin:
             if r.payload is not None
         ]
 
-    async def search_inhibitory(
+    async def search_negation(
         self,
         query_vector: Sequence[float],
         user_id: str,
         org_id: str | None = None,
         limit: int = 10,
-    ) -> list[ScoredResult[InhibitoryFact]]:
-        """Search for similar inhibitory facts.
+    ) -> list[ScoredResult[NegationFact]]:
+        """Search for similar negation facts.
 
         Args:
             query_vector: Query embedding vector.
@@ -250,14 +250,14 @@ class SearchMixin:
             limit: Maximum results to return.
 
         Returns:
-            List of ScoredResult[InhibitoryFact] sorted by similarity.
+            List of ScoredResult[NegationFact] sorted by similarity.
         """
-        from engram.models import InhibitoryFact
+        from engram.models import NegationFact
 
         filters = self._build_filters(user_id, org_id)
 
         results = await self._search(
-            collection="inhibitory",
+            collection="negation",
             query_vector=query_vector,
             filters=filters,
             limit=limit,
@@ -265,7 +265,7 @@ class SearchMixin:
 
         return [
             ScoredResult(
-                memory=self._payload_to_memory(r.payload, InhibitoryFact),
+                memory=self._payload_to_memory(r.payload, NegationFact),
                 score=r.score,
             )
             for r in results

--- a/src/engram/storage/store.py
+++ b/src/engram/storage/store.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from qdrant_client import models
 
 if TYPE_CHECKING:
-    from engram.models import Episode, Fact, InhibitoryFact, ProceduralMemory, SemanticMemory
+    from engram.models import Episode, Fact, NegationFact, ProceduralMemory, SemanticMemory
 
 
 class StoreMixin:
@@ -78,20 +78,20 @@ class StoreMixin:
         """
         return await self._store_memory(memory, "procedural")
 
-    async def store_inhibitory(self, fact: InhibitoryFact) -> str:
-        """Store an inhibitory fact.
+    async def store_negation(self, fact: NegationFact) -> str:
+        """Store a negation fact.
 
         Args:
-            fact: InhibitoryFact to store.
+            fact: NegationFact to store.
 
         Returns:
             The fact ID.
         """
-        return await self._store_memory(fact, "inhibitory")
+        return await self._store_memory(fact, "negation")
 
     async def _store_memory(
         self,
-        memory: Episode | Fact | SemanticMemory | ProceduralMemory | InhibitoryFact,
+        memory: Episode | Fact | SemanticMemory | ProceduralMemory | NegationFact,
         memory_type: str,
     ) -> str:
         """Store a memory in the appropriate collection.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,7 +11,7 @@ from engram.models import (
     Episode,
     ExtractionMethod,
     Fact,
-    InhibitoryFact,
+    NegationFact,
     ProceduralMemory,
     SemanticMemory,
     generate_id,
@@ -535,23 +535,23 @@ class TestProceduralMemory:
         assert mem.trigger_context == "when explaining code"
 
 
-class TestInhibitoryFact:
-    """Tests for InhibitoryFact model."""
+class TestNegationFact:
+    """Tests for NegationFact model."""
 
-    def test_create_inhibitory_fact(self):
-        """Basic inhibitory fact creation."""
-        fact = InhibitoryFact(
+    def test_create_negation_fact(self):
+        """Basic negation fact creation."""
+        fact = NegationFact(
             content="User does NOT use MongoDB",
             negates_pattern="mongodb",
             user_id="user_123",
         )
         assert fact.content == "User does NOT use MongoDB"
         assert fact.negates_pattern == "mongodb"
-        assert fact.id.startswith("inh_")
+        assert fact.id.startswith("neg_")
 
     def test_default_confidence(self):
         """Default confidence should be inferred at 0.7."""
-        fact = InhibitoryFact(
+        fact = NegationFact(
             content="Test negation",
             negates_pattern="test",
             user_id="user_123",
@@ -561,7 +561,7 @@ class TestInhibitoryFact:
 
     def test_str_representation(self):
         """String representation should show negation content."""
-        fact = InhibitoryFact(
+        fact = NegationFact(
             content="User does NOT like verbose output",
             negates_pattern="verbose",
             user_id="user_123",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from engram.config import Settings
-from engram.models import Episode, Fact, InhibitoryFact, ProceduralMemory, SemanticMemory
+from engram.models import Episode, Fact, NegationFact, ProceduralMemory, SemanticMemory
 from engram.service import EncodeResult, EngramService, RecallResult
 from engram.storage import ScoredResult
 
@@ -547,26 +547,26 @@ class TestGetSources:
         mock_service.storage.get_procedural.assert_called_once_with("proc_abc", "user_123")
 
     @pytest.mark.asyncio
-    async def test_get_sources_for_inhibitory(self, mock_service):
-        """Should return source episodes for an inhibitory fact."""
+    async def test_get_sources_for_negation(self, mock_service):
+        """Should return source episodes for a negation fact."""
         source_episode = Episode(
-            id="ep_inh_1", content="I don't like spam", role="user", user_id="user_123"
+            id="ep_neg_1", content="I don't like spam", role="user", user_id="user_123"
         )
-        mock_inhibitory = InhibitoryFact(
-            id="inh_def",
+        mock_negation = NegationFact(
+            id="neg_def",
             content="User does not want promotional emails",
             negates_pattern="promotional emails",
-            source_episode_ids=["ep_inh_1"],
+            source_episode_ids=["ep_neg_1"],
             user_id="user_123",
         )
 
-        mock_service.storage.get_inhibitory.return_value = mock_inhibitory
+        mock_service.storage.get_negation.return_value = mock_negation
         mock_service.storage.get_episode.return_value = source_episode
 
-        episodes = await mock_service.get_sources("inh_def", "user_123")
+        episodes = await mock_service.get_sources("neg_def", "user_123")
 
         assert len(episodes) == 1
-        mock_service.storage.get_inhibitory.assert_called_once_with("inh_def", "user_123")
+        mock_service.storage.get_negation.assert_called_once_with("neg_def", "user_123")
 
     @pytest.mark.asyncio
     async def test_get_sources_fact_not_found(self, mock_service):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -11,7 +11,7 @@ from engram.models import (
     AuditEntry,
     Episode,
     Fact,
-    InhibitoryFact,
+    NegationFact,
     ProceduralMemory,
     SemanticMemory,
 )
@@ -59,7 +59,7 @@ class TestEngramStorageInit:
         assert "test_factual" in names
         assert "test_semantic" in names
         assert "test_procedural" in names
-        assert "test_inhibitory" in names
+        assert "test_negation" in names
         assert "test_audit" in names
 
     async def test_context_manager(self, storage: EngramStorage):
@@ -305,20 +305,20 @@ class TestProceduralMemoryStorage:
         assert retrieved.content == "User likes verbose responses"
 
 
-class TestInhibitoryFactStorage:
-    """Tests for inhibitory fact storage."""
+class TestNegationFactStorage:
+    """Tests for negation fact storage."""
 
-    async def test_store_and_get_inhibitory(self, storage: EngramStorage):
-        """Should store and retrieve inhibitory fact."""
-        fact = InhibitoryFact(
+    async def test_store_and_get_negation(self, storage: EngramStorage):
+        """Should store and retrieve negation fact."""
+        fact = NegationFact(
             content="User does NOT use MongoDB",
             negates_pattern="mongodb",
             user_id="user_123",
             embedding=make_embedding(),
         )
 
-        await storage.store_inhibitory(fact)
-        retrieved = await storage.get_inhibitory(fact.id, "user_123")
+        await storage.store_negation(fact)
+        retrieved = await storage.get_negation(fact.id, "user_123")
 
         assert retrieved is not None
         assert retrieved.content == "User does NOT use MongoDB"


### PR DESCRIPTION
## Summary
- Rename InhibitoryFact → NegationFact throughout codebase
- Clarify documentation to be precise about neuroscience claims
- Emphasize selectivity_score as the genuine connection to Tomé et al. research

## Changes

### Documentation
- Updated architecture.md: clarified that selectivity_score is directly inspired by Tomé et al. research
- Updated that NegationFact is an engineering construct for storing negations, not neural inhibition
- Updated README.md, CLAUDE.md, AGENTS.md, research/competitive.md, research/overview.md

### Code
- Renamed `InhibitoryFact` → `NegationFact` (src/engram/models/negation.py)
- Changed ID prefix from `inh_` to `neg_`
- Renamed collection from `inhibitory` to `negation`
- Updated all storage methods: `get_negation`, `store_negation`, `delete_negation`, `search_negation`
- Updated service layer and API endpoints

### Tests
- Updated test_models.py, test_storage.py, test_service.py

## Related
- Created issue #68 for retrieval-time memory competition (future enhancement)

## Test plan
- [x] All 291 tests pass (excluding 1 unrelated env-var test)
- [x] Pre-commit hooks pass
- [x] mypy passes