### PR TITLE
Add memory_types array API pattern for recall

### DIFF
--- a/src/engram/api/router.py
+++ b/src/engram/api/router.py
@@ -179,6 +179,11 @@ async def recall(
         HTTPException: If recall fails.
     """
     try:
+        # Convert Literal list to str list for service compatibility
+        memory_types: list[str] | None = (
+            list(request.memory_types) if request.memory_types is not None else None
+        )
+
         # Use recall_at for bi-temporal queries, recall for standard queries
         if request.as_of is not None:
             results = await service.recall_at(
@@ -188,8 +193,7 @@ async def recall(
                 org_id=request.org_id,
                 limit=request.limit,
                 min_confidence=request.min_confidence,
-                include_episodes=request.include_episodes,
-                include_facts=request.include_facts,
+                memory_types=memory_types,
             )
         else:
             results = await service.recall(
@@ -199,12 +203,7 @@ async def recall(
                 limit=request.limit,
                 min_confidence=request.min_confidence,
                 min_selectivity=request.min_selectivity,
-                include_episodes=request.include_episodes,
-                include_facts=request.include_facts,
-                include_semantic=request.include_semantic,
-                include_procedural=request.include_procedural,
-                include_negation=request.include_negation,
-                include_working=request.include_working,
+                memory_types=memory_types,
                 include_sources=request.include_sources,
                 follow_links=request.follow_links,
                 max_hops=request.max_hops,

--- a/src/engram/api/schemas.py
+++ b/src/engram/api/schemas.py
@@ -9,6 +9,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from engram.models import Staleness
 
+# Valid memory types for the memory_types parameter
+MemoryType = Literal["episode", "fact", "semantic", "procedural", "negation", "working"]
+ALL_MEMORY_TYPES: set[str] = {"episode", "fact", "semantic", "procedural", "negation", "working"}
+
 
 class EncodeRequest(BaseModel):
     """Request body for encoding a memory.
@@ -108,13 +112,11 @@ class RecallRequest(BaseModel):
         limit: Maximum results to return.
         min_confidence: Minimum confidence for facts.
         min_selectivity: Minimum selectivity for semantic memories (0.0-1.0).
-        include_episodes: Whether to search episodes.
-        include_facts: Whether to search facts.
-        include_semantic: Whether to search semantic memories.
-        include_working: Whether to include working memory.
+        memory_types: List of memory types to search. None means all types.
         include_sources: Whether to include source episodes in results.
         follow_links: Enable multi-hop reasoning via related_ids.
         max_hops: Maximum link traversal depth when follow_links=True.
+        freshness: Freshness mode for results.
         as_of: Optional bi-temporal filter (only memories derived before this time).
     """
 
@@ -130,12 +132,10 @@ class RecallRequest(BaseModel):
     min_selectivity: float = Field(
         default=0.0, ge=0.0, le=1.0, description="Minimum selectivity for semantic memories"
     )
-    include_episodes: bool = Field(default=True, description="Search episodes")
-    include_facts: bool = Field(default=True, description="Search facts")
-    include_semantic: bool = Field(default=True, description="Search semantic memories")
-    include_procedural: bool = Field(default=True, description="Search procedural memories")
-    include_negation: bool = Field(default=True, description="Search negation facts")
-    include_working: bool = Field(default=True, description="Include working memory")
+    memory_types: list[MemoryType] | None = Field(
+        default=None,
+        description="Memory types to search. None means all. Valid: episode, fact, semantic, procedural, negation, working",
+    )
     include_sources: bool = Field(default=False, description="Include source episodes in results")
     follow_links: bool = Field(default=False, description="Enable multi-hop reasoning")
     max_hops: int = Field(default=2, ge=1, le=5, description="Maximum link traversal depth")

--- a/src/engram/service.py
+++ b/src/engram/service.py
@@ -349,12 +349,7 @@ class EngramService:
         limit: int = 10,
         min_confidence: float | None = None,
         min_selectivity: float = 0.0,
-        include_episodes: bool = True,
-        include_facts: bool = True,
-        include_semantic: bool = True,
-        include_procedural: bool = True,
-        include_negation: bool = True,
-        include_working: bool = True,
+        memory_types: list[str] | None = None,
         include_sources: bool = False,
         follow_links: bool = False,
         max_hops: int = 2,
@@ -372,12 +367,8 @@ class EngramService:
             limit: Maximum results per memory type.
             min_confidence: Minimum confidence for facts.
             min_selectivity: Minimum selectivity for semantic memories (0.0-1.0).
-            include_episodes: Whether to search episodes.
-            include_facts: Whether to search facts.
-            include_semantic: Whether to search semantic memories.
-            include_procedural: Whether to search procedural memories.
-            include_negation: Whether to search negation facts.
-            include_working: Whether to include working memory (current session).
+            memory_types: List of memory types to search. None means all types.
+                Valid types: episode, fact, semantic, procedural, negation, working.
             include_sources: Whether to include source episodes in results.
             follow_links: Enable multi-hop reasoning via related_ids.
             max_hops: Maximum link traversal depth when follow_links=True.
@@ -393,7 +384,7 @@ class EngramService:
                 query="phone numbers",
                 user_id="user_123",
                 limit=5,
-                freshness="fresh_only",  # Only consolidated memories
+                memory_types=["fact", "episode"],
             )
             for m in memories:
                 print(f"{m.content} (staleness: {m.staleness})")
@@ -401,13 +392,17 @@ class EngramService:
         """
         start_time = time.monotonic()
 
+        # Determine which memory types to search
+        all_types = {"episode", "fact", "semantic", "procedural", "negation", "working"}
+        types_to_search = set(memory_types) if memory_types is not None else all_types
+
         # Generate query embedding
         query_vector = await self.embedder.embed(query)
 
         results: list[RecallResult] = []
 
         # Search episodes
-        if include_episodes:
+        if "episode" in types_to_search:
             scored_episodes = await self.storage.search_episodes(
                 query_vector=query_vector,
                 user_id=user_id,
@@ -435,7 +430,7 @@ class EngramService:
                 )
 
         # Search facts
-        if include_facts:
+        if "fact" in types_to_search:
             scored_facts = await self.storage.search_facts(
                 query_vector=query_vector,
                 user_id=user_id,
@@ -464,7 +459,7 @@ class EngramService:
                 )
 
         # Search semantic memories
-        if include_semantic:
+        if "semantic" in types_to_search:
             scored_semantics = await self.storage.search_semantic(
                 query_vector=query_vector,
                 user_id=user_id,
@@ -497,7 +492,7 @@ class EngramService:
                 )
 
         # Search procedural memories
-        if include_procedural:
+        if "procedural" in types_to_search:
             scored_procedurals = await self.storage.search_procedural(
                 query_vector=query_vector,
                 user_id=user_id,
@@ -527,7 +522,7 @@ class EngramService:
                 )
 
         # Search negation facts
-        if include_negation:
+        if "negation" in types_to_search:
             scored_negations = await self.storage.search_negation(
                 query_vector=query_vector,
                 user_id=user_id,
@@ -554,7 +549,7 @@ class EngramService:
                 )
 
         # Search working memory (in-memory, no DB round-trip)
-        if include_working and self._working_memory:
+        if "working" in types_to_search and self._working_memory:
             # Filter by user_id (and org_id if specified)
             for ep in self._working_memory:
                 if ep.user_id != user_id:
@@ -628,8 +623,7 @@ class EngramService:
         org_id: str | None = None,
         limit: int = 10,
         min_confidence: float | None = None,
-        include_episodes: bool = True,
-        include_facts: bool = True,
+        memory_types: list[str] | None = None,
     ) -> list[RecallResult]:
         """Recall memories as they existed at a specific point in time.
 
@@ -644,8 +638,7 @@ class EngramService:
             org_id: Optional organization ID filter.
             limit: Maximum results per memory type.
             min_confidence: Minimum confidence for facts.
-            include_episodes: Whether to search episodes.
-            include_facts: Whether to search facts.
+            memory_types: List of memory types to search. None means all types.
 
         Returns:
             List of RecallResult sorted by similarity score.
@@ -662,13 +655,17 @@ class EngramService:
         """
         start_time = time.monotonic()
 
+        # Determine which memory types to search (recall_at only supports episode and fact)
+        all_types = {"episode", "fact"}
+        types_to_search = set(memory_types) & all_types if memory_types is not None else all_types
+
         # Generate query embedding
         query_vector = await self.embedder.embed(query)
 
         results: list[RecallResult] = []
 
         # Search episodes (filter by timestamp <= as_of)
-        if include_episodes:
+        if "episode" in types_to_search:
             scored_episodes = await self.storage.search_episodes(
                 query_vector=query_vector,
                 user_id=user_id,
@@ -693,7 +690,7 @@ class EngramService:
                 )
 
         # Search facts (filter by derived_at <= as_of)
-        if include_facts:
+        if "fact" in types_to_search:
             scored_facts = await self.storage.search_facts(
                 query_vector=query_vector,
                 user_id=user_id,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1118,11 +1118,10 @@ class TestFreshnessHints:
             user_id="user_123",
         )
 
-        # Recall including working memory
+        # Recall including working memory (default includes all types)
         results = await service.recall(
             query="email",
             user_id="user_123",
-            include_working=True,
         )
 
         # Find working memory result
@@ -1148,11 +1147,10 @@ class TestFreshnessHints:
             user_id="user_123",
         )
 
-        # Recall with fresh_only
+        # Recall with fresh_only (default includes all types including working)
         results = await service.recall(
             query="email",
             user_id="user_123",
-            include_working=True,
             freshness="fresh_only",
         )
 


### PR DESCRIPTION
## Summary

Replace the 6 boolean flags with a single `memory_types` array parameter.

**Before:**
```python
response = client.post("/recall", json={
    "query": "find emails",
    "user_id": "u1",
    "include_episodes": True,
    "include_facts": True,
    "include_semantic": False,
    "include_procedural": False,
    "include_negation": False,
    "include_working": False,
})
```

**After:**
```python
response = client.post("/recall", json={
    "query": "find emails",
    "user_id": "u1",
    "memory_types": ["episode", "fact"],
})
```

- `memory_types=None` (default) = search all types
- `memory_types=["episode", "fact"]` = only those types
- `memory_types=[]` = return nothing

No backward compatibility - this is pre-alpha.

## Test plan

- [x] All 64 tests pass
- [x] mypy passes

Closes #67