### PR TITLE
docs: Clarify implementation status of dynamic linking and buffer promotion

### DIFF
--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -115,7 +115,7 @@ for mem in memories:
     print(mem.confidence.explain())  # "0.85: extracted, 3 sources, confirmed yesterday"
 
 # Background operations (run periodically or on-demand)
-await memory.consolidate()  # Extract semantics, build links
+await memory.consolidate()  # Extract semantics (link building planned)
 await memory.decay()        # Update scores, archive stale memories
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,10 +106,17 @@ Enables "what did we know on date X?" queries for debugging and audit.
 
 ### 4. Dynamic Memory Linking
 
-Memories form explicit links to related memories, enabling multi-hop reasoning:
+> **Status**: Infrastructure implemented, link population in progress.
+
+Memories can form explicit links to related memories via `related_ids`, enabling multi-hop reasoning:
 - "User uses PostgreSQL" → "PostgreSQL is relational" → "User prefers relational DBs"
 
-Inspired by A-MEM research showing 2x improvement on multi-hop reasoning benchmarks.
+**Current implementation**:
+- `related_ids` field exists on SemanticMemory and ProceduralMemory
+- `follow_links` parameter in recall() traverses links when populated
+- Consolidation identifies relationships but link storage is not yet implemented
+
+Inspired by A-MEM research showing 2x improvement on multi-hop reasoning benchmarks. Full linking support is tracked in [issue #73](https://github.com/ashita-ai/engram/issues/73).
 
 ### 5. Selectivity Through Consolidation
 

--- a/research/competitive.md
+++ b/research/competitive.md
@@ -146,7 +146,7 @@ Novel approaches from recent literature:
 
 **Results**: 2x improvement on multi-hop reasoning benchmarks.
 
-**Engram**: Implements dynamic linking via `related_ids` field on semantic and procedural memories, populated during consolidation.
+**Engram**: Provides infrastructure for dynamic linking via `related_ids` field on semantic and procedural memories. Link traversal (`follow_links` parameter) is implemented; automated link population during consolidation is planned.
 
 ### Hierarchical Cognitive Buffers
 
@@ -156,7 +156,7 @@ Novel approaches from recent literature:
 
 **Results**: 58.6% memory reuse vs 0% for naive RAG.
 
-**Engram**: Implements buffer promotion hierarchy (Working → Episodic → Semantic → Procedural) with explicit promotion triggers based on importance, repetition, and access patterns.
+**Engram**: Provides the memory type hierarchy (Working → Episodic → Semantic → Procedural). Automated promotion based on importance, repetition, and access patterns is planned but not yet implemented.
 
 ### Dynamic Engrams (Selectivity Through Consolidation)
 


### PR DESCRIPTION
## Summary
- Add status notes clarifying that dynamic linking infrastructure exists but link population during consolidation is not yet implemented
- Hedge claims about buffer promotion to accurately reflect current vs planned implementation
- Update consolidate() API comment to note link building is planned

## Changes
- **architecture.md**: Add status note for dynamic linking showing current implementation vs planned
- **competitive.md**: Hedge claims about dynamic linking and buffer promotion  
- **api-design.md**: Update consolidate() comment

Tracks full linking support in issue #73.

## Test plan
- Documentation only - no code changes