### PR TITLE
style: Fix 4 long line violations (E501)

### DIFF
--- a/src/engram/api/schemas.py
+++ b/src/engram/api/schemas.py
@@ -141,7 +141,7 @@ class RecallRequest(BaseModel):
     )
     memory_types: list[MemoryType] | None = Field(
         default=None,
-        description="Memory types to search. None means all. Valid: episodic, factual, semantic, procedural, negation, working",
+        description="Memory types to search. None means all.",
     )
     include_sources: bool = Field(default=False, description="Include source episodes in results")
     follow_links: bool = Field(default=False, description="Enable multi-hop reasoning")

--- a/src/engram/storage/base.py
+++ b/src/engram/storage/base.py
@@ -141,8 +141,8 @@ class StorageBase:
         Qdrant requires point IDs to be UUIDs or unsigned integers.
         We hash the key to create a deterministic UUID-format string.
         """
-        hash_bytes = hashlib.sha256(key.encode()).hexdigest()[:32]
-        return f"{hash_bytes[:8]}-{hash_bytes[8:12]}-{hash_bytes[12:16]}-{hash_bytes[16:20]}-{hash_bytes[20:32]}"
+        h = hashlib.sha256(key.encode()).hexdigest()[:32]
+        return f"{h[:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
 
     async def _ensure_collections(self) -> None:
         """Ensure all required collections exist with proper schemas."""

--- a/src/engram/workflows/decay.py
+++ b/src/engram/workflows/decay.py
@@ -133,7 +133,8 @@ async def run_decay(
             await storage.delete_semantic(memory.id, user_id)
             deleted += 1
             logger.debug(
-                f"Deleted memory {memory.id}: confidence {old_confidence:.3f} -> {new_confidence:.3f}"
+                f"Deleted memory {memory.id}: "
+                f"confidence {old_confidence:.3f} -> {new_confidence:.3f}"
             )
         elif new_confidence < settings.decay_archive_threshold:
             # Archive memories below archive threshold
@@ -142,7 +143,8 @@ async def run_decay(
                 await storage.update_semantic_memory(memory)
                 archived += 1
                 logger.debug(
-                    f"Archived memory {memory.id}: confidence {old_confidence:.3f} -> {new_confidence:.3f}"
+                    f"Archived memory {memory.id}: "
+                    f"confidence {old_confidence:.3f} -> {new_confidence:.3f}"
                 )
             else:
                 # Already archived, just update confidence


### PR DESCRIPTION
## Summary
Fix 4 long line violations found by ruff E501 check (> 100 chars).

## Changes
- `api/schemas.py:144` - Shortened description for memory_types field
- `storage/base.py:145` - Shortened variable name in hash formatting
- `workflows/decay.py:136,145` - Split long f-strings across lines

## Test Plan
- [x] All ruff checks pass
- [x] All mypy checks pass  
- [x] All 385 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)