### PR TITLE
fix: enable LLM enrichment for negation detection in examples

### DIFF
--- a/examples/external/advanced.py
+++ b/examples/external/advanced.py
@@ -127,10 +127,16 @@ async def main() -> None:
         ]
 
         print("  Batch 3: Corrections and negations...")
+        print("    (Using enrich=True for LLM negation detection)")
         negations_detected = 0
         for role, content in batch3:
             result = await engram.encode(
-                content=content, role=role, user_id=user_id, org_id=org_id, session_id=session_id
+                content=content,
+                role=role,
+                user_id=user_id,
+                org_id=org_id,
+                session_id=session_id,
+                enrich=True,  # Required for negation detection
             )
             negations_detected += len(result.structured.negations)
         print(f"    → {len(batch3)} episodes, {negations_detected} negations detected")
@@ -217,11 +223,13 @@ async def main() -> None:
         for r in results_filtered[:4]:
             print(f"    {r.content[:55]}...")
 
-        removed = len(results_unfiltered) - len(results_filtered)
-        if removed > 0:
-            print(f"\n  ✓ Removed {removed} contradicted result(s) — fewer but accurate")
+        # Check if MongoDB results were filtered
+        unfiltered_mongo = sum(1 for r in results_unfiltered if "mongo" in r.content.lower())
+        filtered_mongo = sum(1 for r in results_filtered if "mongo" in r.content.lower())
+        if unfiltered_mongo > filtered_mongo:
+            print(f"\n  ✓ Filtered {unfiltered_mongo - filtered_mongo} MongoDB result(s)")
         print(
-            "\n  Behavior: Returns fewer results rather than backfilling with irrelevant content."
+            "\n  Behavior: Contradicted results filtered, backfilled with other relevant content."
         )
 
         # =====================================================================

--- a/examples/external/structured.py
+++ b/examples/external/structured.py
@@ -230,8 +230,11 @@ async def main() -> None:
         print(f"  Without negation filter: {len(mongodb_results)} results")
         print(f"  With negation filter:    {len(mongodb_filtered)} results")
 
-        if len(mongodb_results) > len(mongodb_filtered):
-            print("\n  Filtered out content matching 'I don't use MongoDB'")
+        # Check if MongoDB results were filtered
+        unfiltered_mongo = sum(1 for r in mongodb_results if "mongo" in r.content.lower())
+        filtered_mongo = sum(1 for r in mongodb_filtered if "mongo" in r.content.lower())
+        if unfiltered_mongo > filtered_mongo:
+            print(f"\n  ✓ Filtered {unfiltered_mongo - filtered_mongo} MongoDB result(s)")
 
     shutdown_workflows()
 


### PR DESCRIPTION
## Summary
- `advanced.py`: Add `enrich=True` for batch 3 since negation detection requires LLM enrichment
- Both examples: Fix negation filter output to count filtered MongoDB results instead of comparing total counts (backfilling keeps count same)
- Update description to explain that contradicted results are filtered and backfilled with other relevant content

## Changes
The negation filtering was working correctly, but the examples weren't demonstrating it properly:
1. `advanced.py` wasn't using `enrich=True` for the negation batch, so 0 negations were detected
2. Both examples checked if result count decreased, but negation filtering backfills results up to the limit, so the count stays the same while the content changes

## Test plan
- [x] All 366 tests pass
- [x] All 7 examples (3 local, 4 external) run successfully
- [x] Negation detection shows correct counts (5 negations in advanced.py)
- [x] Negation filtering correctly filters MongoDB results