### PR TITLE
feat: implement retrieval tracking and Testing Effect strengthening (#102, #104)

### DIFF
--- a/src/engram/config.py
+++ b/src/engram/config.py
@@ -184,6 +184,18 @@ class Settings(BaseSettings):
         description="Trigger immediate consolidation for episodes at or above this importance",
     )
 
+    # Retrieval Strengthening (Testing Effect)
+    retrieval_strengthening_enabled: bool = Field(
+        default=True,
+        description="Enable Testing Effect: strengthen memories on retrieval",
+    )
+    retrieval_strengthening_delta: float = Field(
+        default=0.05,
+        ge=0.0,
+        le=0.5,
+        description="Strength increase per retrieval (smaller than consolidation's 0.1)",
+    )
+
     # Logging
     log_level: str = Field(
         default="INFO",

--- a/src/engram/models/structured.py
+++ b/src/engram/models/structured.py
@@ -216,6 +216,26 @@ class StructuredMemory(MemoryBase):
         description="ID of the SemanticMemory this was consolidated into",
     )
 
+    # Retrieval tracking (for Testing Effect)
+    retrieval_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of times this memory has been retrieved",
+    )
+    last_accessed: datetime | None = Field(
+        default=None,
+        description="When this memory was last retrieved",
+    )
+
+    def record_access(self) -> None:
+        """Record that this memory was accessed (activation tracking).
+
+        Increments retrieval_count and updates last_accessed timestamp.
+        Called by storage layer on search hits.
+        """
+        self.retrieval_count += 1
+        self.last_accessed = datetime.now(UTC)
+
     @classmethod
     def from_episode_fast(
         cls,

--- a/src/engram/storage/search.py
+++ b/src/engram/storage/search.py
@@ -276,7 +276,7 @@ class SearchMixin:
             org_id: Optional org ID filter.
             limit: Maximum results to return.
             min_confidence: Minimum confidence threshold.
-            track_activation: If True, update access_count and last_accessed
+            track_activation: If True, update retrieval_count and last_accessed
                 for returned memories (A-MEM style activation tracking).
 
         Returns:
@@ -314,7 +314,7 @@ class SearchMixin:
     ) -> None:
         """Update activation metadata for searched procedural memories.
 
-        Records access_count and last_accessed for A-MEM style
+        Records retrieval_count and last_accessed for A-MEM style
         activation-based strengthening.
 
         Args:
@@ -326,14 +326,14 @@ class SearchMixin:
 
         for scored in results:
             memory = scored.memory
-            memory.access_count += 1
+            memory.retrieval_count += 1
             memory.last_accessed = datetime.now(UTC)
 
             # Update just the activation fields in storage
             await self.client.set_payload(
                 collection_name=collection,
                 payload={
-                    "access_count": memory.access_count,
+                    "retrieval_count": memory.retrieval_count,
                     "last_accessed": memory.last_accessed.isoformat(),
                 },
                 points=models.FilterSelector(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -579,28 +579,28 @@ class TestProceduralMemory:
         assert mem.content == "User prefers Python code examples"
         assert mem.id.startswith("proc_")
 
-    def test_default_access_count(self):
-        """Default access count should be 0."""
+    def test_default_retrieval_count(self):
+        """Default retrieval count should be 0."""
         mem = ProceduralMemory(content="Test", user_id="user_123")
-        assert mem.access_count == 0
+        assert mem.retrieval_count == 0
 
     def test_reinforce(self):
-        """reinforce() should increment access count and update last_accessed."""
+        """reinforce() should increment retrieval count and update last_accessed."""
         mem = ProceduralMemory(content="Test", user_id="user_123")
         assert mem.last_accessed is None
         mem.reinforce()
-        assert mem.access_count == 1
+        assert mem.retrieval_count == 1
         assert mem.last_accessed is not None
         first_access = mem.last_accessed
         mem.reinforce()
-        assert mem.access_count == 2
+        assert mem.retrieval_count == 2
         assert mem.last_accessed >= first_access
 
     def test_record_access_alias(self):
         """record_access() should be an alias for reinforce()."""
         mem = ProceduralMemory(content="Test", user_id="user_123")
         mem.record_access()
-        assert mem.access_count == 1
+        assert mem.retrieval_count == 1
         assert mem.last_accessed is not None
 
     def test_add_link(self):


### PR DESCRIPTION
## Summary
- Implements issue #102 (Track retrieval_count and last_retrieved_at)
- Implements issue #104 (Retrieval-triggered memory strengthening - Testing Effect)

## Changes
- Added `retrieval_count` and `last_accessed` fields to StructuredMemory
- Renamed `access_count` to `retrieval_count` in ProceduralMemory for consistency
- Added `consolidation_strength`, `consolidation_passes`, and `strengthen()`/`weaken()` methods to ProceduralMemory
- Added config settings: `retrieval_strengthening_enabled` and `retrieval_strengthening_delta`
- Implemented `_apply_retrieval_strengthening()` in RecallMixin to strengthen memories on retrieval
- Added `update_structured_memory()` to CRUDMixin

## Scientific Foundation
Based on Roediger & Karpicke (2006) Testing Effect research: memories involved in retrieval become stronger and more stable over time. When memories are recalled:
- SemanticMemory and ProceduralMemory get `strengthen(delta)` called, increasing `consolidation_strength` by 0.05 (configurable)
- StructuredMemory tracks `retrieval_count` and `last_accessed` for activation-based analysis
- Episodic memories are immutable and not strengthened

## Test plan
- [x] All 366 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] Updated existing tests to use `retrieval_count` instead of `access_count`

Closes #102
Closes #104