### PR TITLE
feat: implement DELETE REST endpoints for memory management (#80)

### DIFF
--- a/src/engram/api/schemas.py
+++ b/src/engram/api/schemas.py
@@ -405,3 +405,23 @@ class VerificationResponse(BaseModel):
     extraction_method: str = Field(description="How memory was extracted")
     confidence: float = Field(ge=0.0, le=1.0, description="Current confidence score")
     explanation: str = Field(description="Human-readable derivation trace")
+
+
+class BulkDeleteResponse(BaseModel):
+    """Response for bulk delete (GDPR erasure) endpoint.
+
+    Provides counts of deleted memories by type for confirmation.
+
+    Attributes:
+        user_id: User whose memories were deleted.
+        org_id: Optional org filter used.
+        deleted_counts: Count of deleted memories by type.
+        total_deleted: Total number of memories deleted.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str = Field(description="User whose memories were deleted")
+    org_id: str | None = Field(default=None, description="Org filter used (if any)")
+    deleted_counts: dict[str, int] = Field(description="Counts by memory type")
+    total_deleted: int = Field(ge=0, description="Total memories deleted")

--- a/src/engram/models/audit.py
+++ b/src/engram/models/audit.py
@@ -147,6 +147,47 @@ class AuditEntry(BaseModel):
             duration_ms=duration_ms,
         )
 
+    @classmethod
+    def for_delete(
+        cls,
+        user_id: str,
+        memory_id: str,
+        memory_type: str,
+        org_id: str | None = None,
+        duration_ms: int | None = None,
+    ) -> "AuditEntry":
+        """Create audit entry for a delete operation."""
+        return cls(
+            event="delete",
+            user_id=user_id,
+            org_id=org_id,
+            details={
+                "memory_id": memory_id,
+                "memory_type": memory_type,
+            },
+            duration_ms=duration_ms,
+        )
+
+    @classmethod
+    def for_bulk_delete(
+        cls,
+        user_id: str,
+        deleted_counts: dict[str, int],
+        org_id: str | None = None,
+        duration_ms: int | None = None,
+    ) -> "AuditEntry":
+        """Create audit entry for a bulk delete operation (GDPR erasure)."""
+        return cls(
+            event="bulk_delete",
+            user_id=user_id,
+            org_id=org_id,
+            details={
+                "deleted_counts": deleted_counts,
+                "total_deleted": sum(deleted_counts.values()),
+            },
+            duration_ms=duration_ms,
+        )
+
     def __str__(self) -> str:
         """String representation showing event and user."""
         return f"AuditEntry({self.event} by {self.user_id})"


### PR DESCRIPTION
## Summary
Implements issue #80 - DELETE REST endpoints for memory management and GDPR compliance.

## Changes

### New Endpoints
- `DELETE /api/v1/memories/{memory_id}` - Delete a single memory by ID
  - Routes to appropriate delete method based on ID prefix (ep_, struct_, sem_, proc_)
  - Returns 204 on success, 404 if not found, 400 for invalid prefix
  
- `DELETE /api/v1/users/{user_id}/memories` - Bulk delete all user memories (GDPR)
  - Deletes all memories across episodic, structured, semantic, and procedural collections
  - Returns counts of deleted memories by type for confirmation
  - Optional `org_id` filter

### Audit Logging
- Added `AuditEntry.for_delete()` for single memory deletions
- Added `AuditEntry.for_bulk_delete()` for GDPR erasure operations

### Storage Layer
- Added `delete_all_user_memories()` to CRUDMixin for bulk deletion

### API Schemas
- Added `BulkDeleteResponse` schema for bulk delete response

## Test plan
- [x] All 377 tests pass (11 new tests for delete endpoints)
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] Tests cover success cases for all memory types
- [x] Tests cover error cases (404, 400, 503)
- [x] Tests cover bulk delete with/without org filter

Closes #80