### PR TITLE
feat: implement explicit memory linking endpoints (#89)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -327,6 +327,112 @@ Delete all memories for a user (GDPR right to erasure).
 
 ---
 
+## Memory Link Endpoints
+
+Manage explicit links between memories for multi-hop reasoning.
+
+### POST /memories/{memory_id}/links
+
+Create a link between memories.
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `memory_id` | string | Source memory ID (must be `sem_*` or `proc_*`) |
+
+**Request Body:**
+```json
+{
+  "target_id": "sem_target456",
+  "link_type": "related",
+  "user_id": "user_123"
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `target_id` | string | Yes | - | ID of memory to link to |
+| `link_type` | string | No | `"related"` | Link type: `related`, `supersedes`, `contradicts` |
+| `user_id` | string | Yes | - | User ID for isolation |
+
+**Link Types:**
+- `related` - General association (bidirectional)
+- `supersedes` - This memory replaces another (directional)
+- `contradicts` - These memories conflict (bidirectional)
+
+**Response (201 Created):**
+```json
+{
+  "source_id": "sem_abc123",
+  "target_id": "sem_target456",
+  "link_type": "related",
+  "bidirectional": true
+}
+```
+
+---
+
+### GET /memories/{memory_id}/links
+
+List all links from a memory.
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `memory_id` | string | Memory ID (must be `sem_*` or `proc_*`) |
+
+**Query Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | Yes | User ID for isolation |
+
+**Response (200 OK):**
+```json
+{
+  "memory_id": "sem_abc123",
+  "links": [
+    {
+      "target_id": "sem_xyz789",
+      "link_type": "related"
+    },
+    {
+      "target_id": "sem_conflict1",
+      "link_type": "contradicts"
+    }
+  ],
+  "count": 2
+}
+```
+
+---
+
+### DELETE /memories/{memory_id}/links/{target_id}
+
+Remove a link between memories.
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `memory_id` | string | Source memory ID (must be `sem_*` or `proc_*`) |
+| `target_id` | string | Target memory ID to unlink |
+
+**Query Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | Yes | User ID for isolation |
+
+**Response (200 OK):**
+```json
+{
+  "source_id": "sem_abc123",
+  "target_id": "sem_target456",
+  "removed": true,
+  "reverse_removed": true
+}
+```
+
+---
+
 ## Workflow Endpoints
 
 Manually trigger background workflows for consolidation, decay, and memory processing.

--- a/src/engram/api/schemas.py
+++ b/src/engram/api/schemas.py
@@ -659,3 +659,97 @@ class StructureBatchResponse(BaseModel):
     results: list[StructureResponse] = Field(
         default_factory=list, description="Individual episode results"
     )
+
+
+# ============================================================================
+# Memory Link Schemas
+# ============================================================================
+
+# Valid link types
+LinkType = Literal["related", "supersedes", "contradicts"]
+
+
+class CreateLinkRequest(BaseModel):
+    """Request to create a link between memories.
+
+    Attributes:
+        target_id: ID of the memory to link to.
+        link_type: Type of link (related, supersedes, contradicts).
+        user_id: User ID for multi-tenancy isolation.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_id: str = Field(min_length=1, description="ID of the memory to link to")
+    link_type: LinkType = Field(
+        default="related",
+        description="Type of link: related (bidirectional), supersedes (directional), contradicts (bidirectional)",
+    )
+    user_id: str = Field(min_length=1, description="User ID for isolation")
+
+
+class LinkDetail(BaseModel):
+    """Details about a memory link.
+
+    Attributes:
+        target_id: ID of the linked memory.
+        link_type: Type of the link.
+        created_at: When the link was created (if available).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_id: str = Field(description="ID of the linked memory")
+    link_type: str = Field(description="Type of link")
+
+
+class CreateLinkResponse(BaseModel):
+    """Response for link creation.
+
+    Attributes:
+        source_id: ID of the source memory.
+        target_id: ID of the target memory.
+        link_type: Type of link created.
+        bidirectional: Whether a reverse link was also created.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str = Field(description="ID of the source memory")
+    target_id: str = Field(description="ID of the target memory")
+    link_type: str = Field(description="Type of link")
+    bidirectional: bool = Field(description="Whether reverse link was created")
+
+
+class LinksListResponse(BaseModel):
+    """Response for listing memory links.
+
+    Attributes:
+        memory_id: ID of the memory.
+        links: List of links from this memory.
+        count: Number of links.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    memory_id: str = Field(description="ID of the memory")
+    links: list[LinkDetail] = Field(default_factory=list, description="Links from this memory")
+    count: int = Field(ge=0, description="Number of links")
+
+
+class DeleteLinkResponse(BaseModel):
+    """Response for link deletion.
+
+    Attributes:
+        source_id: ID of the source memory.
+        target_id: ID of the removed link target.
+        removed: Whether the link was removed.
+        reverse_removed: Whether the reverse link was also removed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str = Field(description="ID of the source memory")
+    target_id: str = Field(description="ID of the removed link target")
+    removed: bool = Field(description="Whether the link was removed")
+    reverse_removed: bool = Field(description="Whether reverse link was also removed")

--- a/src/engram/models/procedural.py
+++ b/src/engram/models/procedural.py
@@ -49,6 +49,10 @@ class ProceduralMemory(MemoryBase):
         default_factory=list,
         description="Links to related memories",
     )
+    link_types: dict[str, str] = Field(
+        default_factory=dict,
+        description="Maps memory_id to link type (related, supersedes, contradicts)",
+    )
     derived_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC),
         description="When this pattern was identified",
@@ -105,10 +109,42 @@ class ProceduralMemory(MemoryBase):
         """Alias for record_access() for backwards compatibility."""
         self.record_access()
 
-    def add_link(self, memory_id: str) -> None:
-        """Add a link to a related memory."""
+    def add_link(self, memory_id: str, link_type: str = "related") -> None:
+        """Add a link to a related memory.
+
+        Args:
+            memory_id: ID of the memory to link to.
+            link_type: Type of link (related, supersedes, contradicts).
+        """
         if memory_id not in self.related_ids:
             self.related_ids.append(memory_id)
+        self.link_types[memory_id] = link_type
+
+    def remove_link(self, memory_id: str) -> bool:
+        """Remove a link to a related memory.
+
+        Args:
+            memory_id: ID of the memory to unlink.
+
+        Returns:
+            True if the link was removed, False if it didn't exist.
+        """
+        if memory_id in self.related_ids:
+            self.related_ids.remove(memory_id)
+            self.link_types.pop(memory_id, None)
+            return True
+        return False
+
+    def get_link_type(self, memory_id: str) -> str | None:
+        """Get the link type for a related memory.
+
+        Args:
+            memory_id: ID of the linked memory.
+
+        Returns:
+            Link type or None if not linked.
+        """
+        return self.link_types.get(memory_id)
 
     def __str__(self) -> str:
         """String representation showing pattern content."""


### PR DESCRIPTION
## Summary
- Add REST API endpoints for explicit memory linking between semantic and procedural memories
- Support three link types: `related` (bidirectional), `supersedes` (directional), `contradicts` (bidirectional)
- Enable users to manually create associations that complement automatic consolidation links

## Changes
- `src/engram/api/router.py`: Add POST/GET/DELETE endpoints for `/memories/{id}/links`
- `src/engram/api/schemas.py`: Add link request/response schemas (CreateLinkRequest, LinkDetail, LinksListResponse, etc.)
- `src/engram/models/semantic.py`: Add `link_types` field and `remove_link`, `get_link_type` methods
- `src/engram/models/procedural.py`: Same updates as semantic.py
- `docs/api.md`: Add Memory Link Endpoints documentation section
- `tests/test_api.py`: Add 11 new tests for link operations

## API Endpoints
- `POST /api/v1/memories/{memory_id}/links` - Create a link
- `GET /api/v1/memories/{memory_id}/links` - List all links
- `DELETE /api/v1/memories/{memory_id}/links/{target_id}` - Remove a link

## Test plan
- [x] All 57 API tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] Link creation with bidirectional linking for `related` and `contradicts`
- [x] Directional linking for `supersedes`
- [x] Link listing with type information
- [x] Link deletion with reverse removal

Closes #89