### PR TITLE
feat: implement memory update/correction endpoint (#86)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -277,6 +277,66 @@ Verify a memory against its source episodes with explanation.
 
 ---
 
+### PATCH /memories/{memory_id}
+
+Update a memory's content, confidence, or metadata.
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `memory_id` | string | Memory ID (must be `struct_*`, `sem_*`, or `proc_*`) |
+
+**Request Body:**
+```json
+{
+  "content": "Updated content",
+  "confidence": 0.85,
+  "tags": ["updated", "new-tag"],
+  "keywords": ["keyword1", "keyword2"],
+  "context": "New context",
+  "user_id": "user_123"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | string | No | New content (triggers re-embedding) |
+| `confidence` | float | No | New confidence value (0.0-1.0) |
+| `tags` | array | No | New tags list (semantic/procedural only) |
+| `keywords` | array | No | New keywords list (semantic only) |
+| `context` | string | No | New context description (semantic only) |
+| `user_id` | string | Yes | User ID for isolation |
+
+**Supported Fields by Memory Type:**
+- `structured (struct_*)`: content (updates summary), confidence
+- `semantic (sem_*)`: content, confidence, tags, keywords, context
+- `procedural (proc_*)`: content, confidence
+
+**Response (200 OK):**
+```json
+{
+  "memory_id": "sem_abc123",
+  "memory_type": "semantic",
+  "updated": true,
+  "re_embedded": true,
+  "changes": [
+    {
+      "field": "content",
+      "old_value": "Original content",
+      "new_value": "Updated content"
+    }
+  ]
+}
+```
+
+**Errors:**
+- 400: Invalid memory ID format, or attempt to update episodic memory
+- 404: Memory not found
+
+**Note:** Episodic memories (`ep_*`) are immutable and cannot be updated.
+
+---
+
 ### DELETE /memories/{memory_id}
 
 Delete a specific memory by ID.

--- a/src/engram/api/schemas.py
+++ b/src/engram/api/schemas.py
@@ -759,3 +759,70 @@ class DeleteLinkResponse(BaseModel):
     target_id: str = Field(description="ID of the removed link target")
     removed: bool = Field(description="Whether the link was removed")
     reverse_removed: bool = Field(description="Whether reverse link was also removed")
+
+
+# ============================================================================
+# Memory Update Schemas
+# ============================================================================
+
+
+class UpdateMemoryRequest(BaseModel):
+    """Request to update a memory.
+
+    All fields are optional - only provided fields are updated.
+
+    Attributes:
+        content: New content (triggers re-embedding).
+        confidence: New confidence value (0.0-1.0).
+        tags: New tags list (semantic/procedural only).
+        keywords: New keywords list (semantic only).
+        context: New context description (semantic only).
+        user_id: User ID for multi-tenancy isolation.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    content: str | None = Field(default=None, description="New content (triggers re-embedding)")
+    confidence: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="New confidence value"
+    )
+    tags: list[str] | None = Field(default=None, description="New tags list")
+    keywords: list[str] | None = Field(default=None, description="New keywords list")
+    context: str | None = Field(default=None, description="New context description")
+    user_id: str = Field(min_length=1, description="User ID for isolation")
+
+
+class UpdateChange(BaseModel):
+    """Record of a single field change.
+
+    Attributes:
+        field: Name of the changed field.
+        old_value: Previous value (as string for audit).
+        new_value: New value (as string for audit).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str = Field(description="Name of the changed field")
+    old_value: str = Field(description="Previous value")
+    new_value: str = Field(description="New value")
+
+
+class UpdateMemoryResponse(BaseModel):
+    """Response for memory update operation.
+
+    Attributes:
+        memory_id: ID of the updated memory.
+        memory_type: Type of memory (structured, semantic, procedural).
+        updated: Whether any changes were made.
+        re_embedded: Whether content was re-embedded.
+        changes: List of field changes for audit trail.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    memory_id: str = Field(description="ID of the updated memory")
+    memory_type: str = Field(description="Type of memory")
+    updated: bool = Field(description="Whether any changes were made")
+    re_embedded: bool = Field(default=False, description="Whether content was re-embedded")
+    changes: list[UpdateChange] = Field(default_factory=list, description="List of field changes")

--- a/src/engram/models/audit.py
+++ b/src/engram/models/audit.py
@@ -169,6 +169,39 @@ class AuditEntry(BaseModel):
         )
 
     @classmethod
+    def for_update(
+        cls,
+        user_id: str,
+        memory_id: str,
+        memory_type: str,
+        changes: list[dict[str, str]],
+        org_id: str | None = None,
+        duration_ms: int | None = None,
+    ) -> "AuditEntry":
+        """Create audit entry for a memory update operation.
+
+        Args:
+            user_id: User who performed the update.
+            memory_id: ID of the updated memory.
+            memory_type: Type of memory (structured, semantic, procedural).
+            changes: List of changes, each with field, old, new values.
+            org_id: Optional organization ID.
+            duration_ms: Processing duration in milliseconds.
+        """
+        return cls(
+            event="update",
+            user_id=user_id,
+            org_id=org_id,
+            details={
+                "memory_id": memory_id,
+                "memory_type": memory_type,
+                "changes": changes,
+                "change_count": len(changes),
+            },
+            duration_ms=duration_ms,
+        )
+
+    @classmethod
     def for_bulk_delete(
         cls,
         user_id: str,


### PR DESCRIPTION
## Summary
- Add PATCH endpoint for updating memories while maintaining audit trail
- Support content, confidence, tags, keywords, and context updates
- Automatic re-embedding when content changes
- Immutability preserved for episodic memories (returns 400)

## Changes
- `src/engram/api/router.py`: Add PATCH /memories/{memory_id} endpoint
- `src/engram/api/schemas.py`: Add UpdateMemoryRequest, UpdateChange, UpdateMemoryResponse
- `src/engram/models/audit.py`: Add AuditEntry.for_update() method
- `docs/api.md`: Add PATCH endpoint documentation
- `tests/test_api.py`: Add 8 new tests for update scenarios

## Supported Updates by Memory Type
| Memory Type | Updatable Fields |
|-------------|-----------------|
| structured (struct_*) | content (summary), confidence |
| semantic (sem_*) | content, confidence, tags, keywords, context |
| procedural (proc_*) | content, confidence |

## Test plan
- [x] All 54 API tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] Content updates trigger re-embedding
- [x] Episodic memory updates rejected with 400
- [x] Audit trail maintained for all changes

Closes #86