### PR TITLE
feat: implement query expansion for improved recall (#91)

### DIFF
--- a/src/engram/api/router.py
+++ b/src/engram/api/router.py
@@ -234,6 +234,7 @@ async def recall(
                 freshness=request.freshness,
                 include_system_prompts=request.include_system_prompts,
                 diversity=request.diversity,
+                expand_query=request.expand_query,
             )
 
         result_responses = [

--- a/src/engram/api/schemas.py
+++ b/src/engram/api/schemas.py
@@ -177,6 +177,10 @@ class RecallRequest(BaseModel):
         le=1.0,
         description="Diversity parameter for MMR reranking (0.0-1.0). Higher values return more diverse results.",
     )
+    expand_query: bool = Field(
+        default=False,
+        description="Expand query with LLM-generated related terms for better recall",
+    )
 
 
 class SourceEpisodeSummary(BaseModel):

--- a/src/engram/service/query_expansion.py
+++ b/src/engram/service/query_expansion.py
@@ -1,0 +1,166 @@
+"""Query expansion for improved recall.
+
+Uses LLM to expand queries with semantically related terms.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+
+if TYPE_CHECKING:
+    from engram.embeddings import Embedder
+
+logger = logging.getLogger(__name__)
+
+
+class ExpandedQuery(BaseModel):
+    """Result of query expansion.
+
+    Attributes:
+        original: The original query.
+        expanded_terms: List of related terms.
+        reasoning: Brief explanation of why these terms are related.
+    """
+
+    original: str = Field(description="The original query")
+    expanded_terms: list[str] = Field(
+        default_factory=list,
+        max_length=5,
+        description="Related terms (max 5)",
+    )
+    reasoning: str = Field(
+        default="",
+        description="Brief reasoning for the expansion",
+    )
+
+
+# Query expansion agent using Pydantic AI
+_expansion_agent: Agent[None, ExpandedQuery] | None = None
+
+
+def get_expansion_agent(model: str = "openai:gpt-4o-mini") -> Agent[None, ExpandedQuery]:
+    """Get or create the query expansion agent.
+
+    Args:
+        model: LLM model to use for expansion.
+
+    Returns:
+        The query expansion agent.
+    """
+    global _expansion_agent
+    if _expansion_agent is None:
+        _expansion_agent = Agent(
+            model,
+            output_type=ExpandedQuery,
+            system_prompt="""You are a query expansion assistant for a memory system.
+
+Given a search query, generate 2-5 semantically related terms that would help find relevant memories.
+
+Guidelines:
+- Focus on synonyms, related concepts, and alternative phrasings
+- Include both formal and informal variations
+- Consider context where the term might appear
+- Be concise - only include highly relevant terms
+- Don't include the original query term
+
+Examples:
+- "email" → "contact", "address", "mail", "reach"
+- "phone number" → "telephone", "mobile", "cell", "contact"
+- "meeting" → "appointment", "call", "discussion", "scheduled"
+""",
+        )
+    return _expansion_agent
+
+
+async def expand_query(
+    query: str,
+    model: str = "openai:gpt-4o-mini",
+) -> ExpandedQuery:
+    """Expand a query with semantically related terms.
+
+    Uses LLM to generate related terms for the query.
+
+    Args:
+        query: The original search query.
+        model: LLM model to use for expansion.
+
+    Returns:
+        ExpandedQuery with original and expanded terms.
+    """
+    agent = get_expansion_agent(model)
+    try:
+        result = await agent.run(f"Expand this query: {query}")
+        expanded = result.output
+        expanded.original = query  # Ensure original is set
+        logger.debug(f"Expanded '{query}' → {expanded.expanded_terms} ({expanded.reasoning})")
+        return expanded
+    except Exception as e:
+        logger.warning(f"Query expansion failed for '{query}': {e}")
+        # Return original query without expansion on error
+        return ExpandedQuery(original=query, expanded_terms=[], reasoning=f"Expansion failed: {e}")
+
+
+async def get_combined_embedding(
+    query: str,
+    embedder: Embedder,
+    expand: bool = True,
+    expansion_model: str = "openai:gpt-4o-mini",
+) -> list[float]:
+    """Get embedding for query, optionally with expansion.
+
+    When expansion is enabled:
+    1. Expand query to get related terms
+    2. Embed original + expanded terms
+    3. Average embeddings
+
+    Args:
+        query: The search query.
+        embedder: Embedder instance for generating embeddings.
+        expand: Whether to expand the query.
+        expansion_model: LLM model for expansion.
+
+    Returns:
+        Combined embedding vector.
+    """
+    if not expand:
+        return await embedder.embed(query)
+
+    # Expand query
+    expanded = await expand_query(query, expansion_model)
+
+    if not expanded.expanded_terms:
+        # No expansion, just return original embedding
+        return await embedder.embed(query)
+
+    # Embed all terms
+    all_terms = [query] + expanded.expanded_terms
+    embeddings = await embedder.embed_batch(all_terms)
+
+    # Average embeddings (weighted: original gets higher weight)
+    # Weight: original=2, expanded=1 each
+    weights = [2.0] + [1.0] * len(expanded.expanded_terms)
+    total_weight = sum(weights)
+
+    combined = [0.0] * len(embeddings[0])
+    for emb, weight in zip(embeddings, weights, strict=True):
+        for i, val in enumerate(emb):
+            combined[i] += val * weight
+
+    # Normalize
+    combined = [v / total_weight for v in combined]
+
+    logger.info(f"Combined embedding for '{query}' with {len(expanded.expanded_terms)} expansions")
+
+    return combined
+
+
+__all__ = [
+    "ExpandedQuery",
+    "expand_query",
+    "get_combined_embedding",
+    "get_expansion_agent",
+]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -303,6 +303,38 @@ class TestRecallEndpoint:
 
         assert response.status_code == 422
 
+    def test_recall_with_expand_query(self, client, mock_service):
+        """Should pass expand_query parameter to service."""
+        mock_service.recall.return_value = []
+
+        response = client.post(
+            "/api/v1/recall",
+            json={
+                "query": "email address",
+                "user_id": "user_123",
+                "expand_query": True,
+            },
+        )
+
+        assert response.status_code == 200
+        mock_service.recall.assert_called_once()
+        call_kwargs = mock_service.recall.call_args.kwargs
+        assert call_kwargs["expand_query"] is True
+
+    def test_recall_expand_query_default_false(self, client, mock_service):
+        """Should default expand_query to False."""
+        mock_service.recall.return_value = []
+
+        response = client.post(
+            "/api/v1/recall",
+            json={"query": "hello", "user_id": "user_123"},
+        )
+
+        assert response.status_code == 200
+        mock_service.recall.assert_called_once()
+        call_kwargs = mock_service.recall.call_args.kwargs
+        assert call_kwargs["expand_query"] is False
+
     def test_recall_service_not_initialized(self):
         """Should return 503 when service not initialized."""
         app = FastAPI()

--- a/tests/test_query_expansion.py
+++ b/tests/test_query_expansion.py
@@ -1,0 +1,200 @@
+"""Tests for query expansion module."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from engram.service.query_expansion import (
+    ExpandedQuery,
+    expand_query,
+    get_combined_embedding,
+    get_expansion_agent,
+)
+
+
+class TestExpandedQuery:
+    """Tests for ExpandedQuery model."""
+
+    def test_create_with_defaults(self):
+        """Should create with minimal fields."""
+        expanded = ExpandedQuery(original="hello")
+        assert expanded.original == "hello"
+        assert expanded.expanded_terms == []
+        assert expanded.reasoning == ""
+
+    def test_create_with_all_fields(self):
+        """Should create with all fields."""
+        expanded = ExpandedQuery(
+            original="email",
+            expanded_terms=["contact", "address", "mail"],
+            reasoning="Related contact methods",
+        )
+        assert expanded.original == "email"
+        assert len(expanded.expanded_terms) == 3
+        assert "contact" in expanded.expanded_terms
+        assert expanded.reasoning == "Related contact methods"
+
+    def test_max_terms_limit(self):
+        """Should enforce max 5 expanded terms via validation."""
+        # Model allows up to 5 terms
+        expanded = ExpandedQuery(
+            original="test",
+            expanded_terms=["a", "b", "c", "d", "e"],
+        )
+        assert len(expanded.expanded_terms) == 5
+
+
+class TestGetExpansionAgent:
+    """Tests for expansion agent creation."""
+
+    def test_creates_agent(self, monkeypatch):
+        """Should create expansion agent with default model."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key-for-agent-creation")
+        with patch("engram.service.query_expansion._expansion_agent", None):
+            agent = get_expansion_agent()
+            assert agent is not None
+
+    def test_caches_agent(self, monkeypatch):
+        """Should return same agent on repeated calls."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key-for-agent-creation")
+        with patch("engram.service.query_expansion._expansion_agent", None):
+            agent1 = get_expansion_agent()
+            agent2 = get_expansion_agent()
+            assert agent1 is agent2
+
+
+class TestExpandQuery:
+    """Tests for expand_query function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_expanded_query(self):
+        """Should return expanded query from LLM."""
+        mock_result = MagicMock()
+        mock_result.output = ExpandedQuery(
+            original="email",
+            expanded_terms=["contact", "address"],
+            reasoning="Related terms",
+        )
+
+        mock_agent = AsyncMock()
+        mock_agent.run = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "engram.service.query_expansion.get_expansion_agent",
+            return_value=mock_agent,
+        ):
+            result = await expand_query("email")
+            assert result.original == "email"
+            assert "contact" in result.expanded_terms
+            assert "address" in result.expanded_terms
+
+    @pytest.mark.asyncio
+    async def test_handles_error_gracefully(self):
+        """Should return original query on LLM error."""
+        mock_agent = AsyncMock()
+        mock_agent.run = AsyncMock(side_effect=Exception("LLM error"))
+
+        with patch(
+            "engram.service.query_expansion.get_expansion_agent",
+            return_value=mock_agent,
+        ):
+            result = await expand_query("email")
+            assert result.original == "email"
+            assert result.expanded_terms == []
+            assert "failed" in result.reasoning.lower()
+
+
+class TestGetCombinedEmbedding:
+    """Tests for get_combined_embedding function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_original_when_expand_false(self):
+        """Should return original embedding when expand=False."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
+
+        result = await get_combined_embedding(
+            query="email",
+            embedder=mock_embedder,
+            expand=False,
+        )
+
+        assert result == [0.1, 0.2, 0.3]
+        mock_embedder.embed.assert_called_once_with("email")
+
+    @pytest.mark.asyncio
+    async def test_returns_original_when_no_expansion(self):
+        """Should return original embedding when expansion returns no terms."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
+
+        with patch(
+            "engram.service.query_expansion.expand_query",
+            return_value=ExpandedQuery(original="email", expanded_terms=[]),
+        ):
+            result = await get_combined_embedding(
+                query="email",
+                embedder=mock_embedder,
+                expand=True,
+            )
+
+            assert result == [0.1, 0.2, 0.3]
+
+    @pytest.mark.asyncio
+    async def test_combines_embeddings_with_weights(self):
+        """Should combine embeddings with weighted average."""
+        mock_embedder = MagicMock()
+        # Original embedding and 2 expanded term embeddings
+        mock_embedder.embed_batch = AsyncMock(
+            return_value=[
+                [1.0, 0.0, 0.0],  # original (weight 2)
+                [0.0, 1.0, 0.0],  # expanded1 (weight 1)
+                [0.0, 0.0, 1.0],  # expanded2 (weight 1)
+            ]
+        )
+
+        with patch(
+            "engram.service.query_expansion.expand_query",
+            return_value=ExpandedQuery(
+                original="email",
+                expanded_terms=["contact", "address"],
+            ),
+        ):
+            result = await get_combined_embedding(
+                query="email",
+                embedder=mock_embedder,
+                expand=True,
+            )
+
+            # Weighted average: (2*[1,0,0] + 1*[0,1,0] + 1*[0,0,1]) / 4
+            # = [0.5, 0.25, 0.25]
+            assert result[0] == pytest.approx(0.5)
+            assert result[1] == pytest.approx(0.25)
+            assert result[2] == pytest.approx(0.25)
+
+    @pytest.mark.asyncio
+    async def test_embed_batch_called_with_all_terms(self):
+        """Should embed original + expanded terms together."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed_batch = AsyncMock(
+            return_value=[
+                [0.1, 0.2],
+                [0.3, 0.4],
+                [0.5, 0.6],
+            ]
+        )
+
+        with patch(
+            "engram.service.query_expansion.expand_query",
+            return_value=ExpandedQuery(
+                original="email",
+                expanded_terms=["contact", "address"],
+            ),
+        ):
+            await get_combined_embedding(
+                query="email",
+                embedder=mock_embedder,
+                expand=True,
+            )
+
+            mock_embedder.embed_batch.assert_called_once_with(["email", "contact", "address"])


### PR DESCRIPTION
## Summary
- Add LLM-based query expansion to improve recall by generating semantically related terms
- Implement `expand_query` parameter for POST /recall endpoint (default: false)
- Use weighted embedding averaging (original query weighted 2x, expanded terms 1x each)
- Graceful fallback when LLM expansion fails

## Changes
- `src/engram/service/query_expansion.py` (new): ExpandedQuery model, expand_query(), get_combined_embedding()
- `src/engram/service/recall.py`: Add expand_query parameter and use get_combined_embedding
- `src/engram/api/schemas.py`: Add expand_query field to RecallRequest
- `src/engram/api/router.py`: Pass expand_query to service
- `tests/test_query_expansion.py` (new): 11 tests for query expansion module
- `tests/test_api.py`: 2 tests for expand_query parameter
- `docs/api.md`: Document expand_query parameter

## Test plan
- [x] All 417 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] Query expansion falls back gracefully on LLM errors
- [x] expand_query defaults to false for backward compatibility