### PR TITLE
feat: implement proactive contradiction detection (#92)

### DIFF
--- a/src/engram/service/__init__.py
+++ b/src/engram/service/__init__.py
@@ -17,6 +17,7 @@ Example:
 """
 
 from .base import EngramService
+from .contradiction import ConflictDetection
 from .helpers import IMPORTANCE_KEYWORDS, calculate_importance, cosine_similarity
 from .models import (
     EncodeResult,
@@ -29,6 +30,7 @@ from .models import (
 _calculate_importance = calculate_importance
 
 __all__ = [
+    "ConflictDetection",
     "IMPORTANCE_KEYWORDS",
     "EncodeResult",
     "EngramService",

--- a/src/engram/service/base.py
+++ b/src/engram/service/base.py
@@ -42,6 +42,8 @@ from engram.workflows.backend import (
     get_workflow_backend,
 )
 
+from .conflict_ops import ConflictMixin
+from .contradiction import ConflictDetection
 from .encode import EncodeMixin
 from .operations import OperationsMixin
 from .recall import RecallMixin
@@ -51,7 +53,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class EngramService(EncodeMixin, RecallMixin, OperationsMixin):
+class EngramService(EncodeMixin, RecallMixin, OperationsMixin, ConflictMixin):
     """High-level Engram service for encoding and recalling memories.
 
     This service provides a simple interface for:
@@ -59,6 +61,8 @@ class EngramService(EncodeMixin, RecallMixin, OperationsMixin):
     - recall(): Search memories by semantic similarity
     - get_working_memory(): Get current session's episodes
     - clear_working_memory(): Clear session context
+    - get_conflicts(): Get detected memory conflicts
+    - detect_conflicts_in_semantic(): Detect conflicts in semantic memories
 
     Uses dependency injection for storage, embeddings, and workflow backend,
     making it easy to test and configure.
@@ -77,6 +81,9 @@ class EngramService(EncodeMixin, RecallMixin, OperationsMixin):
 
     # Working memory: in-memory episodes for current session (not persisted separately)
     _working_memory: list[Episode] = field(default_factory=list, init=False, repr=False)
+
+    # Detected conflicts: in-memory storage for conflict detection results
+    _conflicts: dict[str, ConflictDetection] = field(default_factory=dict, init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Initialize optional fields after dataclass construction."""

--- a/src/engram/service/conflict_ops.py
+++ b/src/engram/service/conflict_ops.py
@@ -1,0 +1,217 @@
+"""Conflict operations mixin for EngramService.
+
+Provides methods for detecting, storing, and managing memory conflicts.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from .contradiction import (
+    ConflictDetection,
+    detect_contradictions,
+    detect_contradictions_in_structured,
+)
+
+if TYPE_CHECKING:
+    from engram.embeddings import Embedder
+    from engram.storage import EngramStorage
+
+logger = logging.getLogger(__name__)
+
+
+class ConflictMixin:
+    """Mixin providing conflict detection and management functionality.
+
+    Expects these attributes from the base class:
+    - storage: EngramStorage
+    - embedder: Embedder
+    - _conflicts: dict[str, ConflictDetection]
+    """
+
+    storage: EngramStorage
+    embedder: Embedder
+    _conflicts: dict[str, ConflictDetection]
+
+    def get_conflicts(
+        self,
+        user_id: str,
+        org_id: str | None = None,
+        include_resolved: bool = False,
+    ) -> list[ConflictDetection]:
+        """Get detected conflicts for a user.
+
+        Args:
+            user_id: User ID for multi-tenancy.
+            org_id: Optional organization ID filter.
+            include_resolved: Whether to include resolved conflicts.
+
+        Returns:
+            List of ConflictDetection objects.
+        """
+        conflicts = [
+            c
+            for c in self._conflicts.values()
+            if c.user_id == user_id and (org_id is None or c.org_id == org_id)
+        ]
+
+        if not include_resolved:
+            conflicts = [c for c in conflicts if c.resolution is None]
+
+        return sorted(conflicts, key=lambda c: c.detected_at, reverse=True)
+
+    def get_conflict(self, conflict_id: str) -> ConflictDetection | None:
+        """Get a specific conflict by ID.
+
+        Args:
+            conflict_id: The conflict ID.
+
+        Returns:
+            ConflictDetection or None if not found.
+        """
+        return self._conflicts.get(conflict_id)
+
+    def resolve_conflict(
+        self,
+        conflict_id: str,
+        resolution: str,
+    ) -> ConflictDetection | None:
+        """Resolve a conflict with a given resolution.
+
+        Args:
+            conflict_id: The conflict ID.
+            resolution: Resolution type (newer_wins, flag_for_review, lower_confidence, create_negation).
+
+        Returns:
+            Updated ConflictDetection or None if not found.
+        """
+        conflict = self._conflicts.get(conflict_id)
+        if conflict is None:
+            return None
+
+        conflict.resolution = resolution
+        conflict.resolved_at = datetime.now(UTC)
+        return conflict
+
+    def clear_conflicts(
+        self,
+        user_id: str,
+        org_id: str | None = None,
+    ) -> int:
+        """Clear all conflicts for a user.
+
+        Args:
+            user_id: User ID for multi-tenancy.
+            org_id: Optional organization ID filter.
+
+        Returns:
+            Number of conflicts cleared.
+        """
+        to_remove = [
+            cid
+            for cid, c in self._conflicts.items()
+            if c.user_id == user_id and (org_id is None or c.org_id == org_id)
+        ]
+        for cid in to_remove:
+            del self._conflicts[cid]
+        return len(to_remove)
+
+    async def detect_conflicts_in_semantic(
+        self,
+        user_id: str,
+        org_id: str | None = None,
+        similarity_threshold: float = 0.5,
+        model: str = "openai:gpt-4o-mini",
+    ) -> list[ConflictDetection]:
+        """Detect conflicts among all semantic memories.
+
+        Compares all semantic memories to find contradictions.
+
+        Args:
+            user_id: User ID for multi-tenancy.
+            org_id: Optional organization ID filter.
+            similarity_threshold: Minimum similarity to check (0.0-1.0).
+            model: LLM model for conflict analysis.
+
+        Returns:
+            List of detected conflicts.
+        """
+        # Get all semantic memories for the user
+        all_memories = await self.storage.list_semantic_memories(user_id, org_id)
+
+        if len(all_memories) < 2:
+            return []
+
+        # Compare all pairs (using first half vs second half to avoid N^2 comparisons)
+        mid = len(all_memories) // 2
+        new_memories = all_memories[:mid] if mid > 0 else all_memories[:1]
+        existing_memories = all_memories[mid:] if mid > 0 else all_memories[1:]
+
+        conflicts = await detect_contradictions(
+            new_memories=new_memories,
+            existing_memories=existing_memories,
+            embedder=self.embedder,
+            user_id=user_id,
+            org_id=org_id,
+            similarity_threshold=similarity_threshold,
+            model=model,
+        )
+
+        # Store conflicts
+        for conflict in conflicts:
+            self._conflicts[conflict.id] = conflict
+            logger.info(f"Stored conflict {conflict.id}: {conflict.conflict_type}")
+
+        return conflicts
+
+    async def detect_conflicts_in_structured(
+        self,
+        user_id: str,
+        org_id: str | None = None,
+        similarity_threshold: float = 0.5,
+        model: str = "openai:gpt-4o-mini",
+    ) -> list[ConflictDetection]:
+        """Detect conflicts among all structured memories.
+
+        Compares structured memory summaries to find contradictions.
+
+        Args:
+            user_id: User ID for multi-tenancy.
+            org_id: Optional organization ID filter.
+            similarity_threshold: Minimum similarity to check (0.0-1.0).
+            model: LLM model for conflict analysis.
+
+        Returns:
+            List of detected conflicts.
+        """
+        # Get all structured memories for the user
+        all_memories = await self.storage.list_structured_memories(user_id, org_id)
+
+        if len(all_memories) < 2:
+            return []
+
+        # Compare all pairs
+        mid = len(all_memories) // 2
+        new_memories = all_memories[:mid] if mid > 0 else all_memories[:1]
+        existing_memories = all_memories[mid:] if mid > 0 else all_memories[1:]
+
+        conflicts = await detect_contradictions_in_structured(
+            new_memories=new_memories,
+            existing_memories=existing_memories,
+            embedder=self.embedder,
+            user_id=user_id,
+            org_id=org_id,
+            similarity_threshold=similarity_threshold,
+            model=model,
+        )
+
+        # Store conflicts
+        for conflict in conflicts:
+            self._conflicts[conflict.id] = conflict
+
+        return conflicts
+
+
+__all__ = ["ConflictMixin"]

--- a/src/engram/service/contradiction.py
+++ b/src/engram/service/contradiction.py
@@ -1,0 +1,342 @@
+"""Proactive contradiction detection between memories.
+
+Detects conflicts between memories using semantic similarity and LLM analysis.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic_ai import Agent
+
+if TYPE_CHECKING:
+    from engram.embeddings import Embedder
+    from engram.models import SemanticMemory, StructuredMemory
+
+logger = logging.getLogger(__name__)
+
+
+class ConflictDetection(BaseModel):
+    """A detected conflict between two memories.
+
+    Attributes:
+        id: Unique identifier for this conflict.
+        memory_a_id: ID of the first memory.
+        memory_a_content: Content of the first memory.
+        memory_b_id: ID of the second memory.
+        memory_b_content: Content of the second memory.
+        conflict_type: Type of conflict (direct, implicit, temporal).
+        confidence: Confidence that this is a true conflict (0.0-1.0).
+        explanation: LLM explanation of why this is a conflict.
+        resolution: How the conflict was resolved (if resolved).
+        detected_at: When the conflict was detected.
+        resolved_at: When the conflict was resolved (if resolved).
+        user_id: User ID for multi-tenancy.
+        org_id: Optional organization ID.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        default_factory=lambda: f"conflict_{datetime.now(UTC).strftime('%Y%m%d%H%M%S%f')}"
+    )
+    memory_a_id: str = Field(description="ID of the first memory")
+    memory_a_content: str = Field(description="Content of the first memory")
+    memory_b_id: str = Field(description="ID of the second memory")
+    memory_b_content: str = Field(description="Content of the second memory")
+    conflict_type: str = Field(description="Type of conflict: direct, implicit, or temporal")
+    confidence: float = Field(ge=0.0, le=1.0, description="Confidence that this is a true conflict")
+    explanation: str = Field(description="Explanation of the conflict")
+    resolution: str | None = Field(
+        default=None,
+        description="How the conflict was resolved",
+    )
+    detected_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    resolved_at: datetime | None = Field(default=None)
+    user_id: str = Field(description="User ID for multi-tenancy")
+    org_id: str | None = Field(default=None, description="Optional organization ID")
+
+
+class ConflictAnalysis(BaseModel):
+    """LLM output for conflict analysis between two memories."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    is_conflict: bool = Field(description="Whether these memories conflict")
+    conflict_type: str = Field(
+        default="none",
+        description="Type: direct (explicit contradiction), implicit (logical inconsistency), temporal (time-based), none",
+    )
+    confidence: float = Field(
+        ge=0.0, le=1.0, default=0.0, description="Confidence in conflict detection"
+    )
+    explanation: str = Field(default="", description="Explanation of why they conflict or don't")
+    suggested_resolution: str = Field(
+        default="",
+        description="Suggested resolution: newer_wins, flag_for_review, lower_confidence, create_negation",
+    )
+
+
+class BatchConflictAnalysis(BaseModel):
+    """LLM output for batch conflict analysis."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    conflicts: list[ConflictAnalysis] = Field(
+        default_factory=list, description="List of detected conflicts"
+    )
+    pair_indices: list[tuple[int, int]] = Field(
+        default_factory=list, description="Indices of conflicting memory pairs"
+    )
+
+
+_conflict_agent: Agent[None, ConflictAnalysis] | None = None
+
+
+def get_conflict_agent(model: str = "openai:gpt-4o-mini") -> Agent[None, ConflictAnalysis]:
+    """Get or create the conflict detection agent.
+
+    Args:
+        model: LLM model to use for conflict detection.
+
+    Returns:
+        The conflict detection agent.
+    """
+    global _conflict_agent
+    if _conflict_agent is None:
+        _conflict_agent = Agent(
+            model,
+            output_type=ConflictAnalysis,
+            system_prompt="""You are a conflict detection assistant for a memory system.
+
+Given two memories, determine if they contradict each other.
+
+Types of conflicts:
+- DIRECT: Explicit contradiction (e.g., "likes coffee" vs "hates coffee")
+- IMPLICIT: Logical inconsistency (e.g., "vegetarian" vs "favorite steak restaurant")
+- TEMPORAL: Time-based conflict (e.g., "works at Company A" vs "quit Company A last month")
+
+Guidelines:
+- Focus on factual contradictions, not differences in detail
+- Consider context: same topic but different aspects is not a conflict
+- High confidence (>0.8) only for clear, explicit contradictions
+- Medium confidence (0.5-0.8) for implicit or uncertain conflicts
+- Low confidence (<0.5) for potential but unclear conflicts
+
+For resolution suggestions:
+- newer_wins: If one memory is clearly more recent and supersedes the other
+- flag_for_review: If resolution requires human judgment
+- lower_confidence: If both might be valid in different contexts
+- create_negation: If one memory explicitly negates the other""",
+        )
+    return _conflict_agent
+
+
+async def analyze_pair(
+    memory_a_content: str,
+    memory_b_content: str,
+    model: str = "openai:gpt-4o-mini",
+) -> ConflictAnalysis:
+    """Analyze a pair of memories for conflicts.
+
+    Args:
+        memory_a_content: Content of the first memory.
+        memory_b_content: Content of the second memory.
+        model: LLM model to use.
+
+    Returns:
+        ConflictAnalysis with conflict detection results.
+    """
+    agent = get_conflict_agent(model)
+    try:
+        prompt = f"""Analyze these two memories for conflicts:
+
+MEMORY A:
+{memory_a_content}
+
+MEMORY B:
+{memory_b_content}
+
+Determine if they contradict each other and explain why."""
+
+        result = await agent.run(prompt)
+        return result.output
+    except Exception as e:
+        logger.warning(f"Conflict analysis failed: {e}")
+        return ConflictAnalysis(
+            is_conflict=False,
+            conflict_type="none",
+            confidence=0.0,
+            explanation=f"Analysis failed: {e}",
+        )
+
+
+async def detect_contradictions(
+    new_memories: list[SemanticMemory],
+    existing_memories: list[SemanticMemory],
+    embedder: Embedder,
+    user_id: str,
+    org_id: str | None = None,
+    similarity_threshold: float = 0.5,
+    model: str = "openai:gpt-4o-mini",
+) -> list[ConflictDetection]:
+    """Detect contradictions between new and existing memories.
+
+    Uses a two-stage approach:
+    1. Find semantically similar pairs (potential conflicts)
+    2. Use LLM to analyze if they actually conflict
+
+    Args:
+        new_memories: Newly created memories to check.
+        existing_memories: Existing memories to check against.
+        embedder: Embedder for computing similarity.
+        user_id: User ID for multi-tenancy.
+        org_id: Optional organization ID.
+        similarity_threshold: Minimum similarity to consider as potential conflict.
+        model: LLM model for conflict analysis.
+
+    Returns:
+        List of detected conflicts.
+    """
+    from engram.service.helpers import cosine_similarity
+
+    if not new_memories or not existing_memories:
+        return []
+
+    conflicts: list[ConflictDetection] = []
+
+    for new_mem in new_memories:
+        new_embedding = new_mem.embedding
+        if not new_embedding:
+            new_embedding = await embedder.embed(new_mem.content)
+
+        for existing_mem in existing_memories:
+            # Skip self-comparison
+            if new_mem.id == existing_mem.id:
+                continue
+
+            existing_embedding = existing_mem.embedding
+            if not existing_embedding:
+                existing_embedding = await embedder.embed(existing_mem.content)
+
+            # Calculate semantic similarity
+            similarity = cosine_similarity(new_embedding, existing_embedding)
+
+            # Only check pairs that are semantically similar (potential conflicts)
+            if similarity >= similarity_threshold:
+                logger.debug(
+                    f"Checking potential conflict: {new_mem.id} vs {existing_mem.id} "
+                    f"(similarity: {similarity:.2f})"
+                )
+
+                # Use LLM to analyze for actual conflict
+                analysis = await analyze_pair(
+                    new_mem.content,
+                    existing_mem.content,
+                    model=model,
+                )
+
+                if analysis.is_conflict and analysis.confidence >= 0.5:
+                    conflict = ConflictDetection(
+                        memory_a_id=new_mem.id,
+                        memory_a_content=new_mem.content,
+                        memory_b_id=existing_mem.id,
+                        memory_b_content=existing_mem.content,
+                        conflict_type=analysis.conflict_type,
+                        confidence=analysis.confidence,
+                        explanation=analysis.explanation,
+                        user_id=user_id,
+                        org_id=org_id,
+                    )
+                    conflicts.append(conflict)
+                    logger.info(
+                        f"Detected conflict between {new_mem.id} and {existing_mem.id}: "
+                        f"{analysis.conflict_type} ({analysis.confidence:.2f})"
+                    )
+
+    return conflicts
+
+
+async def detect_contradictions_in_structured(
+    new_memories: list[StructuredMemory],
+    existing_memories: list[StructuredMemory],
+    embedder: Embedder,
+    user_id: str,
+    org_id: str | None = None,
+    similarity_threshold: float = 0.5,
+    model: str = "openai:gpt-4o-mini",
+) -> list[ConflictDetection]:
+    """Detect contradictions between StructuredMemory instances.
+
+    Uses summary content for comparison.
+
+    Args:
+        new_memories: Newly created StructuredMemories.
+        existing_memories: Existing StructuredMemories.
+        embedder: Embedder for computing similarity.
+        user_id: User ID for multi-tenancy.
+        org_id: Optional organization ID.
+        similarity_threshold: Minimum similarity to consider.
+        model: LLM model for analysis.
+
+    Returns:
+        List of detected conflicts.
+    """
+    from engram.service.helpers import cosine_similarity
+
+    if not new_memories or not existing_memories:
+        return []
+
+    conflicts: list[ConflictDetection] = []
+
+    for new_mem in new_memories:
+        new_embedding = new_mem.embedding
+        if not new_embedding:
+            new_embedding = await embedder.embed(new_mem.summary)
+
+        for existing_mem in existing_memories:
+            if new_mem.id == existing_mem.id:
+                continue
+
+            existing_embedding = existing_mem.embedding
+            if not existing_embedding:
+                existing_embedding = await embedder.embed(existing_mem.summary)
+
+            similarity = cosine_similarity(new_embedding, existing_embedding)
+
+            if similarity >= similarity_threshold:
+                analysis = await analyze_pair(
+                    new_mem.summary,
+                    existing_mem.summary,
+                    model=model,
+                )
+
+                if analysis.is_conflict and analysis.confidence >= 0.5:
+                    conflict = ConflictDetection(
+                        memory_a_id=new_mem.id,
+                        memory_a_content=new_mem.summary,
+                        memory_b_id=existing_mem.id,
+                        memory_b_content=existing_mem.summary,
+                        conflict_type=analysis.conflict_type,
+                        confidence=analysis.confidence,
+                        explanation=analysis.explanation,
+                        user_id=user_id,
+                        org_id=org_id,
+                    )
+                    conflicts.append(conflict)
+
+    return conflicts
+
+
+__all__ = [
+    "BatchConflictAnalysis",
+    "ConflictAnalysis",
+    "ConflictDetection",
+    "analyze_pair",
+    "detect_contradictions",
+    "detect_contradictions_in_structured",
+    "get_conflict_agent",
+]

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -1,0 +1,260 @@
+"""Tests for contradiction detection module."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from engram.service.contradiction import (
+    ConflictAnalysis,
+    ConflictDetection,
+    analyze_pair,
+    detect_contradictions,
+    get_conflict_agent,
+)
+
+
+class TestConflictDetection:
+    """Tests for ConflictDetection model."""
+
+    def test_create_with_required_fields(self):
+        """Should create with required fields."""
+        conflict = ConflictDetection(
+            memory_a_id="mem_1",
+            memory_a_content="User likes coffee",
+            memory_b_id="mem_2",
+            memory_b_content="User hates coffee",
+            conflict_type="direct",
+            confidence=0.9,
+            explanation="Direct contradiction about coffee preference",
+            user_id="user_123",
+        )
+        assert conflict.memory_a_id == "mem_1"
+        assert conflict.memory_b_id == "mem_2"
+        assert conflict.conflict_type == "direct"
+        assert conflict.confidence == 0.9
+        assert conflict.resolution is None
+        assert conflict.resolved_at is None
+        assert conflict.id.startswith("conflict_")
+
+    def test_create_with_optional_fields(self):
+        """Should create with optional fields."""
+        now = datetime.now(UTC)
+        conflict = ConflictDetection(
+            memory_a_id="mem_1",
+            memory_a_content="Content A",
+            memory_b_id="mem_2",
+            memory_b_content="Content B",
+            conflict_type="temporal",
+            confidence=0.7,
+            explanation="Temporal conflict",
+            user_id="user_123",
+            org_id="org_456",
+            resolution="newer_wins",
+            resolved_at=now,
+        )
+        assert conflict.org_id == "org_456"
+        assert conflict.resolution == "newer_wins"
+        assert conflict.resolved_at == now
+
+
+class TestConflictAnalysis:
+    """Tests for ConflictAnalysis model."""
+
+    def test_create_conflict(self):
+        """Should create conflict analysis."""
+        analysis = ConflictAnalysis(
+            is_conflict=True,
+            conflict_type="direct",
+            confidence=0.85,
+            explanation="Direct contradiction about database preference",
+            suggested_resolution="newer_wins",
+        )
+        assert analysis.is_conflict is True
+        assert analysis.conflict_type == "direct"
+        assert analysis.confidence == 0.85
+
+    def test_create_no_conflict(self):
+        """Should create non-conflict analysis."""
+        analysis = ConflictAnalysis(
+            is_conflict=False,
+            conflict_type="none",
+            confidence=0.0,
+            explanation="No contradiction found",
+        )
+        assert analysis.is_conflict is False
+        assert analysis.conflict_type == "none"
+
+
+class TestGetConflictAgent:
+    """Tests for conflict agent creation."""
+
+    def test_creates_agent(self, monkeypatch):
+        """Should create conflict agent with default model."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key-for-agent-creation")
+        with patch("engram.service.contradiction._conflict_agent", None):
+            agent = get_conflict_agent()
+            assert agent is not None
+
+    def test_caches_agent(self, monkeypatch):
+        """Should return same agent on repeated calls."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key-for-agent-creation")
+        with patch("engram.service.contradiction._conflict_agent", None):
+            agent1 = get_conflict_agent()
+            agent2 = get_conflict_agent()
+            assert agent1 is agent2
+
+
+class TestAnalyzePair:
+    """Tests for analyze_pair function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_conflict_analysis(self):
+        """Should return conflict analysis from LLM."""
+        mock_result = MagicMock()
+        mock_result.output = ConflictAnalysis(
+            is_conflict=True,
+            conflict_type="direct",
+            confidence=0.9,
+            explanation="Direct contradiction",
+        )
+
+        mock_agent = AsyncMock()
+        mock_agent.run = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "engram.service.contradiction.get_conflict_agent",
+            return_value=mock_agent,
+        ):
+            result = await analyze_pair(
+                "User likes coffee",
+                "User hates coffee",
+            )
+            assert result.is_conflict is True
+            assert result.conflict_type == "direct"
+            assert result.confidence == 0.9
+
+    @pytest.mark.asyncio
+    async def test_handles_error_gracefully(self):
+        """Should return no conflict on LLM error."""
+        mock_agent = AsyncMock()
+        mock_agent.run = AsyncMock(side_effect=Exception("LLM error"))
+
+        with patch(
+            "engram.service.contradiction.get_conflict_agent",
+            return_value=mock_agent,
+        ):
+            result = await analyze_pair("Content A", "Content B")
+            assert result.is_conflict is False
+            assert "failed" in result.explanation.lower()
+
+
+class TestDetectContradictions:
+    """Tests for detect_contradictions function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_empty_memories(self):
+        """Should return empty list when no memories."""
+        mock_embedder = MagicMock()
+
+        result = await detect_contradictions(
+            new_memories=[],
+            existing_memories=[],
+            embedder=mock_embedder,
+            user_id="user_123",
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_detects_conflicts_above_threshold(self):
+        """Should detect conflicts when similarity above threshold."""
+        # Create mock semantic memories
+        mock_new_mem = MagicMock()
+        mock_new_mem.id = "sem_new"
+        mock_new_mem.content = "User prefers PostgreSQL"
+        mock_new_mem.embedding = [0.9, 0.1, 0.0]
+
+        mock_existing_mem = MagicMock()
+        mock_existing_mem.id = "sem_existing"
+        mock_existing_mem.content = "User doesn't like SQL databases"
+        mock_existing_mem.embedding = [0.85, 0.15, 0.0]
+
+        mock_embedder = MagicMock()
+        mock_embedder.embed = AsyncMock(return_value=[0.9, 0.1, 0.0])
+
+        mock_analysis = ConflictAnalysis(
+            is_conflict=True,
+            conflict_type="implicit",
+            confidence=0.75,
+            explanation="Implicit contradiction",
+        )
+
+        with patch(
+            "engram.service.contradiction.analyze_pair",
+            return_value=mock_analysis,
+        ):
+            with patch(
+                "engram.service.helpers.cosine_similarity",
+                return_value=0.8,  # Above threshold
+            ):
+                result = await detect_contradictions(
+                    new_memories=[mock_new_mem],
+                    existing_memories=[mock_existing_mem],
+                    embedder=mock_embedder,
+                    user_id="user_123",
+                    similarity_threshold=0.5,
+                )
+
+                assert len(result) == 1
+                assert result[0].memory_a_id == "sem_new"
+                assert result[0].memory_b_id == "sem_existing"
+                assert result[0].conflict_type == "implicit"
+
+    @pytest.mark.asyncio
+    async def test_skips_low_similarity_pairs(self):
+        """Should skip pairs with low similarity."""
+        mock_new_mem = MagicMock()
+        mock_new_mem.id = "sem_new"
+        mock_new_mem.content = "User likes pizza"
+        mock_new_mem.embedding = [1.0, 0.0, 0.0]
+
+        mock_existing_mem = MagicMock()
+        mock_existing_mem.id = "sem_existing"
+        mock_existing_mem.content = "User works at Company X"
+        mock_existing_mem.embedding = [0.0, 1.0, 0.0]
+
+        mock_embedder = MagicMock()
+
+        with patch(
+            "engram.service.helpers.cosine_similarity",
+            return_value=0.2,  # Below threshold
+        ):
+            result = await detect_contradictions(
+                new_memories=[mock_new_mem],
+                existing_memories=[mock_existing_mem],
+                embedder=mock_embedder,
+                user_id="user_123",
+                similarity_threshold=0.5,
+            )
+
+            assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_self_comparison(self):
+        """Should skip comparing memory with itself."""
+        mock_mem = MagicMock()
+        mock_mem.id = "sem_same"
+        mock_mem.content = "Same content"
+        mock_mem.embedding = [1.0, 0.0, 0.0]
+
+        mock_embedder = MagicMock()
+
+        # Even with same memory in both lists, should skip
+        result = await detect_contradictions(
+            new_memories=[mock_mem],
+            existing_memories=[mock_mem],
+            embedder=mock_embedder,
+            user_id="user_123",
+        )
+
+        assert len(result) == 0


### PR DESCRIPTION
## Summary
- Add proactive contradiction detection between memories using semantic similarity and LLM analysis
- Support three conflict types: direct, implicit, and temporal contradictions
- Conflicts stored in-memory (volatile, session-scoped) with full CRUD API

## Changes
- `src/engram/service/contradiction.py` (new): ConflictDetection, ConflictAnalysis models, detect_contradictions()
- `src/engram/service/conflict_ops.py` (new): ConflictMixin with get/resolve/clear methods
- `src/engram/service/base.py`: Add ConflictMixin to EngramService
- `src/engram/api/router.py`: Add conflict detection REST endpoints
- `src/engram/api/schemas.py`: Add conflict request/response schemas
- `tests/test_contradiction.py` (new): 12 tests for contradiction detection
- `docs/api.md`: Document conflict detection endpoints

## API Endpoints
- `POST /conflicts/detect` - Detect contradictions using LLM
- `GET /conflicts` - List detected conflicts
- `GET /conflicts/{conflict_id}` - Get specific conflict
- `POST /conflicts/{conflict_id}/resolve` - Resolve a conflict
- `DELETE /conflicts` - Clear all conflicts

## Test plan
- [x] All 416 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] Conflict detection handles empty memories gracefully
- [x] Low-similarity pairs are skipped to reduce LLM calls