### PR TITLE
refactor: remove backwards compatibility cruft and update documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,11 +352,21 @@ Each call increases `consolidation_strength` by 0.1 and increments `consolidatio
 
 **How we implement it**: Working memory → Episodic → StructuredMemory → SemanticMemory → ProceduralMemory hierarchy. Each tier serves different retention and retrieval purposes.
 
+### Surprise-Based Importance (Adaptive Compression)
+
+**What it is**: Novel information receives higher importance scores than redundant content.
+
+**Primary Research**:
+> Nagy et al. (2025). "Adaptive Compression for Memory-Augmented Language Models." https://arxiv.org/abs/2502.14842
+
+**Key insight**: Information-theoretic surprise (low similarity to existing memories) indicates novel, valuable content worth retaining.
+
+**How we implement it**: During episode encoding, `_calculate_surprise()` computes novelty by comparing embeddings to existing memories. Low similarity = high surprise = boosted importance score. Controlled by `surprise_scoring_enabled`, `surprise_weight` (default 0.15), and `surprise_search_limit` settings.
+
 ### What we DON'T implement
 
 - **Exact biological mechanisms**: We use cognitive science as inspiration, not blueprint
 - **True context selectivity**: Tomé et al. (2024) describes how engrams become more context-specific via inhibitory plasticity. We don't model this — we track consolidation involvement instead
-- **Surprise-based importance**: Nagy et al. (2025) adaptive compression uses information-theoretic surprise. Future work (see #106)
 - **Retrieval-induced forgetting**: Removed in v0.x due to context mismatch between human lab experiments and AI systems
 
 ---

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Engram isn't just storage—it's a system that learns:
 
 - **Irrelevant stuff fades away** — Memories decay over time. Unimportant memories fade; important ones persist. This keeps the store relevant.
 
-- **Retrieval suppresses competitors** — Based on [Anderson et al. (1994)](https://pubmed.ncbi.nlm.nih.gov/7931095/), when memories are retrieved, similar non-retrieved memories are suppressed. Enable with `rif_enabled=True` on recall to naturally prune redundant memories.
+- **Novel memories get priority** — Based on [Nagy et al. (2025)](https://arxiv.org/abs/2502.14842) adaptive compression, information-theoretic surprise increases importance scores. Content similar to existing memories is naturally deprioritized.
 
 ### Fast Path Stays Fast
 

--- a/src/engram/models/procedural.py
+++ b/src/engram/models/procedural.py
@@ -106,7 +106,11 @@ class ProceduralMemory(MemoryBase):
         self.last_accessed = datetime.now(UTC)
 
     def reinforce(self) -> None:
-        """Alias for record_access() for backwards compatibility."""
+        """Reinforce this memory through retrieval or synthesis.
+
+        Semantic alias for record_access() used in consolidation workflows
+        when procedural patterns are strengthened through repeated use.
+        """
         self.record_access()
 
     def add_link(self, memory_id: str, link_type: str = "related") -> None:

--- a/src/engram/models/semantic.py
+++ b/src/engram/models/semantic.py
@@ -211,25 +211,6 @@ class SemanticMemory(MemoryBase):
         """Weaken memory (pruned or contradicted during consolidation)."""
         self.consolidation_strength = max(0.0, self.consolidation_strength - delta)
 
-    # Backwards compatibility aliases
-    def increase_selectivity(self, delta: float = 0.1) -> None:
-        """Deprecated: Use strengthen() instead."""
-        self.strengthen(delta)
-
-    def decrease_selectivity(self, delta: float = 0.1) -> None:
-        """Deprecated: Use weaken() instead."""
-        self.weaken(delta)
-
-    @property
-    def selectivity_score(self) -> float:
-        """Deprecated: Use consolidation_strength instead."""
-        return self.consolidation_strength
-
-    @selectivity_score.setter
-    def selectivity_score(self, value: float) -> None:
-        """Deprecated: Use consolidation_strength instead."""
-        self.consolidation_strength = value
-
     def record_access(self) -> None:
         """Record that this memory was accessed (activation tracking).
 

--- a/src/engram/service/__init__.py
+++ b/src/engram/service/__init__.py
@@ -26,9 +26,6 @@ from .models import (
     VerificationResult,
 )
 
-# Backwards compatibility alias
-_calculate_importance = calculate_importance
-
 __all__ = [
     "ConflictDetection",
     "IMPORTANCE_KEYWORDS",
@@ -37,7 +34,6 @@ __all__ = [
     "RecallResult",
     "SourceEpisodeSummary",
     "VerificationResult",
-    "_calculate_importance",
     "calculate_importance",
     "cosine_similarity",
 ]

--- a/src/engram/service/operations.py
+++ b/src/engram/service/operations.py
@@ -501,7 +501,7 @@ class OperationsMixin:
                     staleness=Staleness.FRESH,
                     consolidated_at=sem.derived_at.isoformat(),
                     metadata={
-                        "selectivity": sem.selectivity_score,
+                        "consolidation_strength": sem.consolidation_strength,
                         "derived_at": sem.derived_at.isoformat(),
                         "linked": True,
                     },

--- a/src/engram/service/recall.py
+++ b/src/engram/service/recall.py
@@ -452,7 +452,7 @@ class RecallMixin:
                     staleness=Staleness.FRESH,
                     consolidated_at=sem.derived_at.isoformat(),
                     metadata={
-                        "selectivity": sem.selectivity_score,
+                        "consolidation_strength": sem.consolidation_strength,
                         "derived_at": sem.derived_at.isoformat(),
                     },
                 )

--- a/src/engram/storage/search.py
+++ b/src/engram/storage/search.py
@@ -207,10 +207,10 @@ class SearchMixin:
             if r.payload is not None
         ]
 
-        # Filter by selectivity if specified
+        # Filter by consolidation strength if specified
         if min_selectivity > 0.0:
             scored_results = [
-                sr for sr in scored_results if sr.memory.selectivity_score >= min_selectivity
+                sr for sr in scored_results if sr.memory.consolidation_strength >= min_selectivity
             ][:limit]
 
         # A-MEM style activation tracking

--- a/src/engram/workflows/__init__.py
+++ b/src/engram/workflows/__init__.py
@@ -57,7 +57,7 @@ from .consolidation import (
     run_consolidation_from_structured,
 )
 from .decay import DecayResult, run_decay
-from .promotion import PromotionResult, run_promotion
+from .promotion import SynthesisResult, run_synthesis
 from .structure import (
     LLMExtractionOutput,
     StructureResult,
@@ -232,7 +232,7 @@ Apply conservative decay - when uncertain, retain.""",
         return self._decay_agent
 
 
-# Convenience functions for simple usage (maintain backward compatibility)
+# Global factory instance for simple usage
 _factory: DurableAgentFactory | None = None
 
 
@@ -296,7 +296,7 @@ __all__ = [
     "PrefectBackend",
     "get_workflow_backend",
     "get_inprocess_backend",
-    # Legacy DurableAgentFactory (for Pydantic AI agent wrapping)
+    # Agent factory (for Pydantic AI agent wrapping)
     "DurableAgentFactory",
     "DurableBackend",
     "init_workflows",
@@ -306,7 +306,7 @@ __all__ = [
     # Workflow results
     "ConsolidationResult",
     "DecayResult",
-    "PromotionResult",
+    "SynthesisResult",
     "ExtractedFact",
     "IdentifiedLink",
     "LLMExtractionResult",
@@ -316,7 +316,7 @@ __all__ = [
     "run_consolidation",
     "run_consolidation_from_structured",
     "run_decay",
-    "run_promotion",
+    "run_synthesis",
     "run_structure",
     "run_structure_batch",
 ]

--- a/src/engram/workflows/consolidation.py
+++ b/src/engram/workflows/consolidation.py
@@ -76,11 +76,6 @@ class ConsolidationResult(BaseModel):
     semantic_memories_created: int = Field(ge=0)
     links_created: int = Field(ge=0, default=0)
     compression_ratio: float = Field(ge=0.0, default=0.0)
-    # Legacy fields for backwards compatibility
-    negations_created: int = Field(ge=0, default=0)
-    evolutions_applied: int = Field(ge=0, default=0)
-    memories_strengthened: int = Field(ge=0, default=0)
-    contradictions_found: list[str] = Field(default_factory=list)
 
 
 def format_episodes_for_llm(episodes: list[dict[str, str]]) -> str:

--- a/src/engram/workflows/decay.py
+++ b/src/engram/workflows/decay.py
@@ -166,21 +166,25 @@ async def run_decay(
         f"{low_access_archived} low-access archived, {deleted} deleted"
     )
 
-    # 5. Run promotion workflow if requested
+    # 5. Run synthesis workflow if requested
     procedural_promoted = 0
     if run_promotion and embedder is not None:
-        from engram.workflows.promotion import run_promotion as _run_promotion
+        from engram.workflows.promotion import run_synthesis
 
-        promotion_result = await _run_promotion(
+        synthesis_result = await run_synthesis(
             storage=storage,
             embedder=embedder,
             user_id=user_id,
             org_id=org_id,
         )
-        procedural_promoted = promotion_result.procedural_created
-        logger.info(f"Promotion complete: {procedural_promoted} procedural memories created")
+        procedural_promoted = (
+            1 if synthesis_result.procedural_created or synthesis_result.procedural_updated else 0
+        )
+        logger.info(
+            f"Synthesis complete: {procedural_promoted} procedural memories created/updated"
+        )
     elif run_promotion and embedder is None:
-        logger.warning("Skipping promotion: embedder not provided")
+        logger.warning("Skipping synthesis: embedder not provided")
 
     return DecayResult(
         memories_updated=updated,

--- a/src/engram/workflows/promotion.py
+++ b/src/engram/workflows/promotion.py
@@ -263,40 +263,8 @@ async def run_synthesis(
         )
 
 
-# Legacy exports for backwards compatibility
-class PromotionResult(BaseModel):
-    """Legacy result class for backwards compatibility."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    memories_analyzed: int = Field(ge=0)
-    procedural_created: int = Field(ge=0)
-    patterns_detected: list[str] = Field(default_factory=list)
-
-
-async def run_promotion(
-    storage: EngramStorage,
-    embedder: Embedder,
-    user_id: str,
-    org_id: str | None = None,
-) -> PromotionResult:
-    """Legacy function - calls run_synthesis internally.
-
-    Deprecated: Use run_synthesis() instead.
-    """
-    result = await run_synthesis(storage, embedder, user_id, org_id)
-
-    return PromotionResult(
-        memories_analyzed=result.semantics_analyzed,
-        procedural_created=1 if result.procedural_created or result.procedural_updated else 0,
-        patterns_detected=[],
-    )
-
-
 __all__ = [
-    "PromotionResult",
     "SynthesisOutput",
     "SynthesisResult",
-    "run_promotion",
     "run_synthesis",
 ]

--- a/tests/test_consolidation.py
+++ b/tests/test_consolidation.py
@@ -211,13 +211,11 @@ class TestConsolidationResult:
             semantic_memories_created=1,
             links_created=3,
             compression_ratio=10.0,
-            contradictions_found=["Conflict A", "Conflict B"],
         )
         assert result.episodes_processed == 10
         assert result.semantic_memories_created == 1
         assert result.links_created == 3
         assert result.compression_ratio == 10.0
-        assert len(result.contradictions_found) == 2
 
     def test_counts_non_negative(self) -> None:
         """Test counts cannot be negative."""
@@ -228,16 +226,14 @@ class TestConsolidationResult:
                 links_created=0,
             )
 
-    def test_legacy_fields_have_defaults(self) -> None:
-        """Test legacy fields have zero defaults."""
+    def test_default_values(self) -> None:
+        """Test default values for optional fields."""
         result = ConsolidationResult(
             episodes_processed=5,
             semantic_memories_created=1,
-            links_created=0,
         )
-        assert result.negations_created == 0
-        assert result.evolutions_applied == 0
-        assert result.memories_strengthened == 0
+        assert result.links_created == 0
+        assert result.compression_ratio == 0.0
 
 
 class TestFormatEpisodesForLLM:
@@ -691,26 +687,6 @@ class TestConsolidationLinking:
 
 class TestConsolidationStrengthening:
     """Tests for memory strengthening during consolidation (Testing Effect)."""
-
-    def test_consolidation_result_has_strengthened_field(self) -> None:
-        """Test ConsolidationResult includes memories_strengthened field."""
-        result = ConsolidationResult(
-            episodes_processed=5,
-            semantic_memories_created=1,
-            links_created=2,
-            evolutions_applied=1,
-            memories_strengthened=4,
-        )
-        assert result.memories_strengthened == 4
-
-    def test_consolidation_result_strengthened_default_zero(self) -> None:
-        """Test memories_strengthened defaults to 0."""
-        result = ConsolidationResult(
-            episodes_processed=1,
-            semantic_memories_created=1,
-            links_created=0,
-        )
-        assert result.memories_strengthened == 0
 
     @pytest.mark.asyncio
     async def test_existing_memory_strengthened_on_link(self) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -430,20 +430,6 @@ class TestSemanticMemory:
         mem.weaken(delta=0.1)
         assert mem.consolidation_strength == 0.0
 
-    def test_backwards_compat_selectivity_property(self):
-        """Deprecated selectivity_score property should work for backwards compat."""
-        mem = SemanticMemory(content="Test", user_id="user_123")
-        mem.consolidation_strength = 0.5
-        assert mem.selectivity_score == 0.5  # Read via deprecated property
-        mem.selectivity_score = 0.7  # Write via deprecated property
-        assert mem.consolidation_strength == 0.7
-
-    def test_backwards_compat_increase_selectivity(self):
-        """Deprecated increase_selectivity should work for backwards compat."""
-        mem = SemanticMemory(content="Test", user_id="user_123")
-        mem.increase_selectivity()
-        assert mem.consolidation_strength == 0.1
-
     def test_str_representation(self):
         """String representation should show content preview."""
         mem = SemanticMemory(content="Short content", user_id="user_123")


### PR DESCRIPTION
Documentation updates:
- README.md: Replace false rif_enabled claim with surprise-based importance
- AGENTS.md: Add Surprise-Based Importance section, remove from "DON'T implement"
- procedural.py: Fix reinforce() docstring (actively used, not backwards compat)

Dead code removal:
- service/__init__.py: Remove _calculate_importance alias (never used)
- semantic.py: Remove selectivity_score property and increase/decrease_selectivity methods
- promotion.py: Remove PromotionResult class and run_promotion wrapper
- consolidation.py: Remove legacy fields (negations_created, evolutions_applied, etc.)

Production code migration:
- operations.py, recall.py, search.py: Use consolidation_strength instead of selectivity_score
- decay.py: Use run_synthesis directly instead of legacy run_promotion wrapper
- workflows/__init__.py: Export SynthesisResult/run_synthesis instead of legacy names

Test updates:
- test_models.py: Remove backwards compat selectivity tests
- test_promotion.py: Remove TestPromotionResult and TestRunPromotionLegacy classes
- test_consolidation.py: Remove legacy field tests, update ConsolidationResult tests

All 463 tests pass.