### PR TITLE
feat: implement memory search by metadata filters (#84)

### DIFF
--- a/src/engram/api/schemas.py
+++ b/src/engram/api/schemas.py
@@ -137,6 +137,57 @@ class GetMemoryResponse(BaseModel):
     metadata: dict[str, object] = Field(default_factory=dict)
 
 
+# Valid sort fields for memory listing
+SortField = Literal["created_at", "confidence"]
+SortOrder = Literal["asc", "desc"]
+
+
+class MemoryListItem(BaseModel):
+    """A single memory item in a list response.
+
+    Attributes:
+        id: Memory ID.
+        memory_type: Type of memory (episodic, structured, semantic, procedural).
+        content: The memory content (preview, may be truncated).
+        user_id: User ID.
+        org_id: Optional org ID.
+        session_id: Session ID (for episodic memories).
+        confidence: Confidence score (None for episodic).
+        created_at: ISO timestamp of creation.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    memory_type: str
+    content: str
+    user_id: str
+    org_id: str | None = None
+    session_id: str | None = None
+    confidence: float | None = None
+    created_at: str
+
+
+class MemoryListResponse(BaseModel):
+    """Response for listing memories with metadata filters.
+
+    Attributes:
+        memories: List of memory items.
+        total: Total number of matching memories (before pagination).
+        limit: Maximum items returned per page.
+        offset: Number of items skipped.
+        has_more: Whether there are more items available.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    memories: list[MemoryListItem] = Field(default_factory=list)
+    total: int = Field(ge=0, description="Total matching memories")
+    limit: int = Field(ge=1, description="Page size")
+    offset: int = Field(ge=0, description="Items skipped")
+    has_more: bool = Field(description="Whether more items are available")
+
+
 class EncodeResponse(BaseModel):
     """Response body for encode operation.
 


### PR DESCRIPTION
## Summary
- Add `GET /memories` endpoint for filtering memories without semantic search
- Support filters: `user_id` (required), `session_id`, `memory_types`, `created_after`/`created_before`, `min_confidence`
- Support sorting by `created_at` or `confidence` (asc/desc)
- Support pagination with `limit`/`offset`

## Changes
- `src/engram/api/schemas.py`: Add `MemoryListResponse`, `MemoryListItem`, `SortField`, `SortOrder` schemas
- `src/engram/api/router.py`: Add `GET /memories` endpoint with comprehensive validation
- `src/engram/storage/crud.py`: Add `search_memories` method with helper methods for each memory type
- `tests/test_api.py`: Add 15 comprehensive tests for filter combinations

## API Example
```
GET /memories?user_id=u1&memory_types=episodic,semantic&limit=20

Response:
{
  "memories": [
    {"id": "ep_xxx", "memory_type": "episodic", "content": "...", ...},
    {"id": "sem_yyy", "memory_type": "semantic", ...}
  ],
  "total": 150,
  "limit": 20,
  "offset": 0,
  "has_more": true
}
```

## Test plan
- [x] All 620 tests pass
- [x] 15 new tests for list memories endpoint
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Pre-commit hooks pass

Closes #84