### PR TITLE
feat: implement bulk encode endpoint (#83)

### DIFF
--- a/src/engram/config.py
+++ b/src/engram/config.py
@@ -335,6 +335,14 @@ class Settings(BaseSettings):
         description="Default rate limit per minute for other endpoints",
     )
 
+    # Batch Operations
+    batch_encode_max_items: int = Field(
+        default=100,
+        ge=1,
+        le=1000,
+        description="Maximum items allowed in a single batch encode request",
+    )
+
     model_config = {
         "env_prefix": "ENGRAM_",
         "env_file": ".env",


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/encode/batch` endpoint for efficiently importing multiple memories
- Configurable batch size limit via `ENGRAM_BATCH_ENCODE_MAX_ITEMS` (default: 100)
- Graceful partial failure handling with detailed per-item results

## Changes

### Endpoint (`src/engram/api/router.py`)
- `POST /encode/batch`: Accept array of encode items with shared user context
- Returns results for each item with success/failure status and error messages
- Validates batch size against configurable limit

### Schemas (`src/engram/api/schemas.py`)
- `BatchEncodeItem`: Per-item content, role, and importance
- `BatchEncodeRequest`: Shared user_id, org_id, session_id, enrich, continue_on_error
- `BatchEncodeItemResult`: Success/failure status with episode/structured data or error
- `BatchEncodeResponse`: Total/succeeded/failed counts with results array

### Configuration (`src/engram/config.py`)
- `batch_encode_max_items`: Configurable limit (default 100, max 1000)

## Example Request
```json
{
  "user_id": "user_123",
  "items": [
    {"content": "Message 1", "role": "user"},
    {"content": "Response 1", "role": "assistant"},
    {"content": "Message 2", "role": "user"}
  ]
}
```

## Test plan
- [x] All 843 tests pass (`uv run pytest tests/ -v --no-cov`)
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] 8 new tests for batch encode endpoint
- [x] Tests cover: success, partial failures, limits, options

Closes #83