### PR TITLE
refactor: code cleanup and documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,15 @@ Episode (raw, immutable)
 | `GET` | `/conflicts` | List detected conflicts |
 | `POST` | `/webhooks` | Register event webhooks |
 | `GET` | `/memories/{id}/history` | Memory change history |
-| `DELETE` | `/memories/user/{user_id}` | GDPR erasure |
+| `DELETE` | `/users/{user_id}/memories` | GDPR erasure |
+
+### Session Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/sessions` | List sessions for a user |
+| `GET` | `/sessions/{session_id}` | Get session details with episodes |
+| `DELETE` | `/sessions/{session_id}` | Delete session (with cascade options) |
 
 ## Confidence Scoring
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1016,6 +1016,114 @@ Clear all conflicts for a user.
 
 ---
 
+## Session Endpoints
+
+Session management endpoints for listing and managing memory sessions.
+
+### GET /sessions
+
+List all sessions for a user with episode counts and date ranges.
+
+**Query Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | Yes | User ID for isolation |
+| `org_id` | string | No | Optional org filter |
+
+**Response (200 OK):**
+```json
+{
+  "sessions": [
+    {
+      "session_id": "session_abc123",
+      "episode_count": 5,
+      "first_episode_at": "2025-01-01T10:00:00Z",
+      "last_episode_at": "2025-01-01T11:00:00Z"
+    }
+  ],
+  "count": 1
+}
+```
+
+---
+
+### GET /sessions/{session_id}
+
+Get details for a specific session including all episodes.
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `session_id` | string | Session identifier |
+
+**Query Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | Yes | User ID for isolation |
+| `org_id` | string | No | Optional org filter |
+
+**Response (200 OK):**
+```json
+{
+  "session_id": "session_abc123",
+  "user_id": "user_123",
+  "org_id": null,
+  "episodes": [
+    {
+      "id": "ep_xyz789",
+      "content": "Hello",
+      "role": "user",
+      "user_id": "user_123",
+      "session_id": "session_abc123",
+      "importance": 0.5,
+      "created_at": "2025-01-01T10:00:00Z"
+    }
+  ],
+  "episode_count": 1,
+  "first_episode_at": "2025-01-01T10:00:00Z",
+  "last_episode_at": "2025-01-01T10:00:00Z"
+}
+```
+
+---
+
+### DELETE /sessions/{session_id}
+
+Delete all episodes in a session with optional cascade to derived memories.
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `session_id` | string | Session identifier |
+
+**Query Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | Yes | User ID for isolation |
+| `org_id` | string | No | Optional org filter |
+| `cascade` | string | No | Cascade mode: `none`, `soft` (default), `hard` |
+
+**Cascade Modes:**
+- `none`: Delete only episodes, leave derived memories orphaned
+- `soft`: Remove references, reduce confidence, delete empty derived memories
+- `hard`: Delete all derived memories that reference session episodes
+
+**Response (200 OK):**
+```json
+{
+  "session_id": "session_abc123",
+  "deleted": true,
+  "episodes_deleted": 5,
+  "structured_deleted": 5,
+  "semantic_deleted": 1,
+  "semantic_updated": 0,
+  "procedural_deleted": 0,
+  "procedural_updated": 1
+}
+```
+
+---
+
 ## Error Responses
 
 All endpoints return standard error responses:

--- a/src/engram/api/helpers.py
+++ b/src/engram/api/helpers.py
@@ -1,0 +1,69 @@
+"""API helper functions to reduce code duplication.
+
+Provides:
+- Memory type detection from ID prefixes
+- Response object builders
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from engram.models import Episode
+
+from .schemas import EpisodeResponse
+
+# Memory ID prefix to type mapping
+MEMORY_ID_PREFIXES: dict[str, str] = {
+    "ep_": "episodic",
+    "struct_": "structured",
+    "sem_": "semantic",
+    "proc_": "procedural",
+}
+
+MemoryTypeStr = Literal["episodic", "structured", "semantic", "procedural"]
+
+
+def get_memory_type_from_id(memory_id: str) -> MemoryTypeStr | None:
+    """Determine memory type from ID prefix.
+
+    Args:
+        memory_id: Memory identifier with type prefix.
+
+    Returns:
+        Memory type string, or None if prefix not recognized.
+
+    Examples:
+        >>> get_memory_type_from_id("ep_abc123")
+        'episodic'
+        >>> get_memory_type_from_id("sem_xyz789")
+        'semantic'
+        >>> get_memory_type_from_id("unknown_123")
+        None
+    """
+    for prefix, memory_type in MEMORY_ID_PREFIXES.items():
+        if memory_id.startswith(prefix):
+            return memory_type  # type: ignore[return-value]
+    return None
+
+
+def episode_to_response(episode: Episode) -> EpisodeResponse:
+    """Convert an Episode model to an EpisodeResponse.
+
+    Args:
+        episode: The Episode model instance.
+
+    Returns:
+        EpisodeResponse with all fields mapped.
+    """
+    return EpisodeResponse(
+        id=episode.id,
+        content=episode.content,
+        role=episode.role,
+        user_id=episode.user_id,
+        org_id=episode.org_id,
+        session_id=episode.session_id,
+        importance=episode.importance,
+        created_at=episode.timestamp.isoformat(),
+    )


### PR DESCRIPTION
## Summary
Comprehensive code quality improvements and documentation updates based on codebase analysis.

## API Code Quality
- **Pydantic compliance**: Convert `AuthenticatedUser` and `RateLimitInfo` from dataclasses to Pydantic BaseModel (per CLAUDE.md requirements)
- **DRY improvements**: Create `src/engram/api/helpers.py` with:
  - `get_memory_type_from_id()` - replaces 3 repeated ID prefix check blocks
  - `episode_to_response()` - replaces 5 repeated EpisodeResponse constructions
- **Code reduction**: ~100 lines of duplicated code eliminated

## Documentation Fixes
- **README.md**: Fix GDPR endpoint path (`/memories/user/{user_id}` → `/users/{user_id}/memories`)
- **README.md**: Add session endpoints section with GET/DELETE descriptions
- **docs/api.md**: Add complete session endpoints documentation with request/response examples

## Test plan
- [x] All 113 API tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] No breaking changes to API contracts

## Not addressed in this PR (future work)
- Duplicate `_fetch_memory_by_id` in service files (requires careful coordination)
- Additional endpoint documentation gaps identified in analysis