### PR TITLE
feat: implement MCP server for Claude Code integration (#81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,31 @@ uv run pre-commit install
 uv run pre-commit run --all-files
 ```
 
+## Claude Code Integration
+
+Engram provides an MCP server for direct integration with Claude Code:
+
+```json
+{
+  "mcpServers": {
+    "engram": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/engram", "--extra", "mcp", "python", "-m", "engram.mcp"]
+    }
+  }
+}
+```
+
+This exposes four tools: `engram_encode`, `engram_recall`, `engram_verify`, and `engram_stats`.
+
+See [docs/mcp.md](docs/mcp.md) for full setup instructions.
+
 ## Documentation
 
 - [Architecture](docs/architecture.md) — Memory types, data flow, storage design
 - [Development Guide](docs/development.md) — Setup, configuration, workflow
 - [API Reference](docs/api.md) — Detailed endpoint documentation
+- [MCP Integration](docs/mcp.md) — Claude Code and MCP client setup
 
 ## Status
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,216 @@
+# MCP Server Integration
+
+Engram provides an MCP (Model Context Protocol) server that allows Claude Code and other MCP-compatible clients to use Engram as a memory system directly from within their environment.
+
+## Overview
+
+The MCP server exposes four tools:
+
+| Tool | Description |
+|------|-------------|
+| `engram_encode` | Store a memory with automatic content extraction |
+| `engram_recall` | Search memories by semantic similarity |
+| `engram_verify` | Verify memory provenance back to sources |
+| `engram_stats` | Get memory statistics for a user |
+
+## Setup
+
+### Prerequisites
+
+1. **Qdrant** must be running (default: `http://localhost:6333`)
+
+   ```bash
+   docker run -p 6333:6333 qdrant/qdrant
+   ```
+
+2. Install Engram with the MCP extra:
+
+   ```bash
+   cd engram
+   uv sync --extra mcp
+   ```
+
+### Claude Code Configuration
+
+Add Engram to your Claude Code MCP settings (`~/.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "engram": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/engram", "--extra", "mcp", "python", "-m", "engram.mcp"]
+    }
+  }
+}
+```
+
+Replace `/path/to/engram` with the actual path to your Engram installation.
+
+### Environment Variables
+
+The MCP server uses the same environment variables as the main Engram service:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENGRAM_QDRANT_URL` | `http://localhost:6333` | Qdrant connection URL |
+| `ENGRAM_EMBEDDING_PROVIDER` | `fastembed` | Embedding backend (`fastembed` or `openai`) |
+| `OPENAI_API_KEY` | - | Required if using `openai` embedding provider |
+
+## Usage Examples
+
+Once configured, the tools are available in Claude Code:
+
+### Storing Memories
+
+```
+Use engram_encode to store "My email is john@example.com and I prefer Python" for user_id "demo"
+```
+
+This will:
+1. Store the content as an immutable episode
+2. Extract structured data (emails, phones, URLs via regex)
+3. Return the episode ID and extracted data
+
+### Searching Memories
+
+```
+Use engram_recall to search for "programming language preferences" for user_id "demo"
+```
+
+This returns semantically similar memories ranked by relevance score.
+
+### Verifying Provenance
+
+```
+Use engram_verify to verify memory "struct_abc123" for user_id "demo"
+```
+
+This traces the memory back to its source episode and explains how it was derived.
+
+### Getting Statistics
+
+```
+Use engram_stats for user_id "demo"
+```
+
+Returns counts of all memory types and enrichment status.
+
+## Tool Reference
+
+### engram_encode
+
+Store a memory with automatic content extraction.
+
+**Parameters:**
+- `content` (required): The text content to store
+- `user_id` (required): User identifier for isolation
+- `role` (optional): Source role - "user", "assistant", or "system" (default: "user")
+- `session_id` (optional): Session identifier for grouping
+- `enrich` (optional): If true, use LLM extraction for richer data (default: false)
+
+**Returns:** JSON with episode_id, structured_id, and extracted data
+
+### engram_recall
+
+Search memories by semantic similarity.
+
+**Parameters:**
+- `query` (required): Natural language search query
+- `user_id` (required): User identifier for isolation
+- `limit` (optional): Maximum results (default: 10)
+- `min_confidence` (optional): Minimum confidence threshold (0.0-1.0)
+- `memory_types` (optional): Comma-separated list of types to search (episodic, structured, semantic, procedural, working)
+- `include_sources` (optional): Include source episode details (default: false)
+
+**Returns:** JSON array of matching memories with scores
+
+### engram_verify
+
+Verify a memory's provenance.
+
+**Parameters:**
+- `memory_id` (required): Memory ID (must start with struct_, sem_, or proc_)
+- `user_id` (required): User identifier for isolation
+
+**Returns:** JSON with verification result, source episodes, and explanation
+
+### engram_stats
+
+Get memory statistics for a user.
+
+**Parameters:**
+- `user_id` (required): User identifier
+
+**Returns:** JSON with counts of all memory types
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                  Claude Code                     │
+│    (or other MCP-compatible client)             │
+└────────────────────┬────────────────────────────┘
+                     │ STDIO (JSON-RPC)
+                     ▼
+┌─────────────────────────────────────────────────┐
+│              Engram MCP Server                   │
+│  ┌─────────────┐  ┌─────────────┐              │
+│  │engram_encode│  │engram_recall│  ...          │
+│  └──────┬──────┘  └──────┬──────┘              │
+│         │                │                       │
+│         ▼                ▼                       │
+│  ┌──────────────────────────────────────────┐  │
+│  │            EngramService                  │  │
+│  │  (encode, recall, verify operations)     │  │
+│  └────────────────────┬─────────────────────┘  │
+└───────────────────────┼─────────────────────────┘
+                        │
+                        ▼
+              ┌─────────────────┐
+              │     Qdrant      │
+              │ (Vector Store)  │
+              └─────────────────┘
+```
+
+## Running Manually
+
+For testing or debugging, you can run the MCP server directly:
+
+```bash
+# Run with uv
+uv run --extra mcp python -m engram.mcp
+
+# The server communicates via STDIO (JSON-RPC)
+# It will wait for MCP protocol messages on stdin
+```
+
+## Troubleshooting
+
+### "Connection refused" to Qdrant
+
+Ensure Qdrant is running:
+
+```bash
+docker run -p 6333:6333 qdrant/qdrant
+```
+
+### "mcp module not found"
+
+Install with the MCP extra:
+
+```bash
+uv sync --extra mcp
+```
+
+### Tool calls failing silently
+
+Check the Engram logs. The MCP server logs to stderr (stdout is reserved for MCP protocol):
+
+```bash
+ENGRAM_LOG_LEVEL=DEBUG uv run --extra mcp python -m engram.mcp
+```
+
+### Memory not persisting
+
+Ensure you're using consistent `user_id` values across encode and recall operations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ sentence-transformers = ["sentence-transformers>=2.3"]
 # Durable execution backends
 prefect = ["prefect>=2.0"]
 
+# MCP server for Claude Code integration
+mcp = ["mcp>=1.2.0"]
+
 # All providers
 all = [
     "anthropic>=0.18",

--- a/src/engram/mcp/__init__.py
+++ b/src/engram/mcp/__init__.py
@@ -1,0 +1,29 @@
+"""MCP server for Engram.
+
+Provides Model Context Protocol (MCP) tools for Claude Code and other
+MCP-compatible clients to interact with Engram's memory system.
+
+Example usage with Claude Code:
+
+    Add to your Claude Code MCP settings:
+    ```json
+    {
+      "mcpServers": {
+        "engram": {
+          "command": "uv",
+          "args": ["run", "--extra", "mcp", "python", "-m", "engram.mcp"]
+        }
+      }
+    }
+    ```
+
+Available tools:
+- engram_encode: Store a memory with content extraction
+- engram_recall: Search memories by semantic similarity
+- engram_verify: Verify memory provenance back to sources
+- engram_stats: Get memory statistics for a user
+"""
+
+from .server import create_server, main
+
+__all__ = ["create_server", "main"]

--- a/src/engram/mcp/__main__.py
+++ b/src/engram/mcp/__main__.py
@@ -1,0 +1,13 @@
+"""Entry point for running Engram MCP server as a module.
+
+Usage:
+    python -m engram.mcp
+
+Or with uv:
+    uv run --extra mcp python -m engram.mcp
+"""
+
+from .server import main
+
+if __name__ == "__main__":
+    main()

--- a/src/engram/mcp/server.py
+++ b/src/engram/mcp/server.py
@@ -1,0 +1,292 @@
+"""MCP server implementation for Engram.
+
+This module provides an MCP (Model Context Protocol) server that exposes
+Engram's memory capabilities as tools that can be used by Claude Code
+and other MCP-compatible clients.
+
+The server uses STDIO transport for communication, which is the standard
+for local MCP servers integrated with Claude Code.
+
+Tools provided:
+- engram_encode: Store a memory and extract structured data
+- engram_recall: Search memories by semantic similarity
+- engram_verify: Verify a memory's provenance
+- engram_stats: Get memory statistics for a user
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from engram.config import Settings
+from engram.service import EngramService
+
+# Configure logging to stderr (stdout is reserved for MCP protocol)
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
+
+
+def create_server() -> FastMCP:
+    """Create and configure the MCP server with Engram tools.
+
+    Returns:
+        Configured FastMCP server instance.
+    """
+    mcp = FastMCP("engram")
+
+    # Shared service instance (lazy initialization)
+    _service: EngramService | None = None
+    _service_lock = asyncio.Lock()
+
+    async def get_service() -> EngramService:
+        """Get or create the shared EngramService instance."""
+        nonlocal _service
+        async with _service_lock:
+            if _service is None:
+                settings = Settings()
+                _service = EngramService.create(settings)
+                await _service.initialize()
+            return _service
+
+    @mcp.tool()
+    async def engram_encode(
+        content: str,
+        user_id: str,
+        role: str = "user",
+        session_id: str | None = None,
+        enrich: bool = False,
+    ) -> str:
+        """Store a memory with automatic content extraction.
+
+        Encodes content into Engram's memory system, extracting structured
+        data like emails, phone numbers, URLs, and (optionally with enrich=True)
+        LLM-extracted entities like people, preferences, and negations.
+
+        Args:
+            content: The text content to store as a memory.
+            user_id: User identifier for multi-tenancy isolation.
+            role: Role of the content source (user, assistant, system).
+            session_id: Optional session identifier for grouping memories.
+            enrich: If True, use LLM extraction for richer data (slower but more complete).
+
+        Returns:
+            JSON string with episode ID and extracted data summary.
+
+        Example:
+            >>> engram_encode("My email is john@example.com", user_id="user_123")
+            '{"episode_id": "ep_...", "emails": ["john@example.com"], ...}'
+        """
+        service = await get_service()
+        result = await service.encode(
+            content=content,
+            role=role,
+            user_id=user_id,
+            session_id=session_id,
+            enrich=enrich,
+        )
+
+        # Build response with key information
+        response: dict[str, Any] = {
+            "episode_id": result.episode.id,
+            "structured_id": result.structured.id,
+            "emails": result.structured.emails,
+            "phones": result.structured.phones,
+            "urls": result.structured.urls,
+            "enriched": result.structured.enriched,
+        }
+
+        # Include LLM-extracted data if enriched
+        if result.structured.enriched:
+            response["people"] = [p.model_dump() for p in result.structured.people]
+            response["preferences"] = [p.model_dump() for p in result.structured.preferences]
+            response["negations"] = [n.model_dump() for n in result.structured.negations]
+            if result.structured.summary:
+                response["summary"] = result.structured.summary
+
+        return json.dumps(response, indent=2)
+
+    @mcp.tool()
+    async def engram_recall(
+        query: str,
+        user_id: str,
+        limit: int = 10,
+        min_confidence: float | None = None,
+        memory_types: str | None = None,
+        include_sources: bool = False,
+    ) -> str:
+        """Search memories by semantic similarity.
+
+        Retrieves memories that are semantically similar to the query,
+        searching across different memory types (episodic, structured,
+        semantic, procedural).
+
+        Args:
+            query: Natural language query to search for.
+            user_id: User identifier for multi-tenancy isolation.
+            limit: Maximum number of results to return (default: 10).
+            min_confidence: Minimum confidence threshold (0.0-1.0) for filtering.
+            memory_types: Comma-separated list of types to search (e.g., "episodic,semantic").
+                        Valid types: episodic, structured, semantic, procedural, working.
+                        If not specified, searches all types.
+            include_sources: If True, include source episode details for derived memories.
+
+        Returns:
+            JSON string with list of matching memories and their scores.
+
+        Example:
+            >>> engram_recall("email address", user_id="user_123")
+            '[{"memory_type": "structured", "content": "...", "score": 0.89, ...}]'
+        """
+        service = await get_service()
+
+        # Parse memory_types if provided
+        types_list: list[str] | None = None
+        if memory_types:
+            types_list = [t.strip() for t in memory_types.split(",")]
+
+        results = await service.recall(
+            query=query,
+            user_id=user_id,
+            limit=limit,
+            min_confidence=min_confidence,
+            memory_types=types_list,
+            include_sources=include_sources,
+        )
+
+        # Convert results to serializable format
+        response: list[dict[str, Any]] = []
+        for r in results:
+            item: dict[str, Any] = {
+                "memory_type": r.memory_type,
+                "memory_id": r.memory_id,
+                "content": r.content,
+                "score": round(r.score, 4),
+            }
+            if r.confidence is not None:
+                item["confidence"] = round(r.confidence, 4)
+            if r.source_episode_id:
+                item["source_episode_id"] = r.source_episode_id
+            if r.source_episode_ids:
+                item["source_episode_ids"] = r.source_episode_ids
+            if r.source_episodes:
+                item["source_episodes"] = [
+                    {"id": s.id, "content": s.content, "role": s.role, "timestamp": s.timestamp}
+                    for s in r.source_episodes
+                ]
+            if r.related_ids:
+                item["related_ids"] = r.related_ids
+
+            response.append(item)
+
+        return json.dumps(response, indent=2)
+
+    @mcp.tool()
+    async def engram_verify(
+        memory_id: str,
+        user_id: str,
+    ) -> str:
+        """Verify a memory's provenance back to source episodes.
+
+        Traces a derived memory (structured, semantic, or procedural) back
+        to its source episode(s) and provides an explanation of how it was
+        derived, including confidence breakdown.
+
+        Args:
+            memory_id: ID of the memory to verify (must start with struct_, sem_, or proc_).
+            user_id: User identifier for multi-tenancy isolation.
+
+        Returns:
+            JSON string with verification result including source episodes and explanation.
+
+        Example:
+            >>> engram_verify("struct_abc123", user_id="user_123")
+            '{"verified": true, "explanation": "Pattern-matched from source...", ...}'
+        """
+        service = await get_service()
+
+        try:
+            result = await service.verify(memory_id=memory_id, user_id=user_id)
+
+            response: dict[str, Any] = {
+                "memory_id": result.memory_id,
+                "memory_type": result.memory_type,
+                "content": result.content,
+                "verified": result.verified,
+                "extraction_method": result.extraction_method,
+                "confidence": round(result.confidence, 4),
+                "explanation": result.explanation,
+                "source_episodes": result.source_episodes,
+            }
+
+            return json.dumps(response, indent=2)
+
+        except Exception as e:
+            return json.dumps({"error": str(e), "memory_id": memory_id}, indent=2)
+
+    @mcp.tool()
+    async def engram_stats(
+        user_id: str,
+    ) -> str:
+        """Get memory statistics for a user.
+
+        Returns counts and summaries of the user's memories across all types,
+        useful for understanding the state of the memory system.
+
+        Args:
+            user_id: User identifier to get statistics for.
+
+        Returns:
+            JSON string with memory counts by type and confidence statistics.
+
+        Example:
+            >>> engram_stats(user_id="user_123")
+            '{"episodic_count": 42, "structured_count": 42, "semantic_count": 5, ...}'
+        """
+        service = await get_service()
+
+        # Get comprehensive stats from storage
+        stats = await service.storage.get_memory_stats(user_id)
+
+        # Build response with key information
+        response: dict[str, Any] = {
+            "user_id": user_id,
+            "episodic_count": stats.episodes,
+            "structured_count": stats.structured,
+            "semantic_count": stats.semantic,
+            "procedural_count": stats.procedural,
+            "total_memories": stats.episodes + stats.structured + stats.semantic + stats.procedural,
+            "pending_consolidation": stats.pending_consolidation,
+        }
+
+        # Add confidence statistics if available
+        if stats.structured_avg_confidence is not None:
+            response["structured_avg_confidence"] = round(stats.structured_avg_confidence, 4)
+        if stats.structured_min_confidence is not None:
+            response["structured_min_confidence"] = round(stats.structured_min_confidence, 4)
+        if stats.structured_max_confidence is not None:
+            response["structured_max_confidence"] = round(stats.structured_max_confidence, 4)
+        if stats.semantic_avg_confidence is not None:
+            response["semantic_avg_confidence"] = round(stats.semantic_avg_confidence, 4)
+
+        return json.dumps(response, indent=2)
+
+    return mcp
+
+
+def main() -> None:
+    """Run the MCP server with STDIO transport."""
+    mcp = create_server()
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -999,6 +999,9 @@ google = [
 groq = [
     { name = "groq" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 prefect = [
     { name = "prefect" },
 ]
@@ -1030,6 +1033,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25" },
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "marimo", marker = "extra == 'demo'", specifier = ">=0.1" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "nameparser", specifier = ">=1.1.3" },
     { name = "openai", specifier = ">=1.0" },
@@ -1054,7 +1058,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.20" },
     { name = "validators", specifier = ">=0.20" },
 ]
-provides-extras = ["dev", "demo", "anthropic", "google", "groq", "cohere", "sentence-transformers", "prefect", "all"]
+provides-extras = ["dev", "demo", "anthropic", "google", "groq", "cohere", "sentence-transformers", "prefect", "mcp", "all"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pre-commit", specifier = ">=4.5.1" }]


### PR DESCRIPTION
## Summary
- Add MCP server module with four tools: `engram_encode`, `engram_recall`, `engram_verify`, and `engram_stats`
- Add `mcp` optional dependency to pyproject.toml (`mcp>=1.2.0`)
- Add comprehensive MCP integration documentation in `docs/mcp.md`
- Update README with Claude Code integration section

## MCP Tools

| Tool | Description |
|------|-------------|
| `engram_encode` | Store a memory with automatic content extraction |
| `engram_recall` | Search memories by semantic similarity |
| `engram_verify` | Verify memory provenance back to sources |
| `engram_stats` | Get memory statistics for a user |

## Claude Code Configuration

```json
{
  "mcpServers": {
    "engram": {
      "command": "uv",
      "args": ["run", "--directory", "/path/to/engram", "--extra", "mcp", "python", "-m", "engram.mcp"]
    }
  }
}
```

## Files Changed
- `src/engram/mcp/__init__.py` - Module init with exports
- `src/engram/mcp/__main__.py` - Entry point for `python -m engram.mcp`
- `src/engram/mcp/server.py` - FastMCP server with tool implementations
- `docs/mcp.md` - Comprehensive integration documentation
- `README.md` - Added Claude Code integration section
- `pyproject.toml` - Added `mcp` optional dependency

## Test plan
- [x] Module imports successfully
- [x] All pre-commit hooks pass (ruff, mypy, formatting)
- [x] Existing tests continue to pass
- [ ] Manual test with Claude Code (requires running Qdrant)

Closes #81