### PR TITLE
security: address code review findings #151, #154, #155

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,18 @@ Environment variables (prefix: `ENGRAM_`):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `ENV` | `development` | Environment: `development`, `production`, or `test` |
 | `QDRANT_URL` | `http://localhost:6333` | Qdrant connection |
 | `EMBEDDING_PROVIDER` | `fastembed` | Embedding backend |
-| `AUTH_ENABLED` | `false` | Enable Bearer token auth |
+| `AUTH_ENABLED` | auto | Enable Bearer token auth (auto: true in production) |
+| `AUTH_SECRET_KEY` | - | Secret key for auth (required in production) |
 | `RATE_LIMIT_ENABLED` | `false` | Enable rate limiting |
 | `BATCH_ENCODE_MAX_ITEMS` | `100` | Max batch size |
+
+**Security Notes:**
+- In production (`ENGRAM_ENV=production`), auth is enabled by default
+- Using the default secret key in production will raise an error
+- Generate a secret key: `python -c "import secrets; print(secrets.token_hex(32))"`
 
 See [docs/development.md](docs/development.md) for full configuration reference.
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -101,10 +101,16 @@ class TestEncodeRecallWorkflow:
     def service(self, mock_storage, mock_embedder):
         """Create a service with mock dependencies."""
         settings = Settings(openai_api_key="sk-test-dummy")
-        return EngramService(
+        workflow_backend = AsyncMock()
+
+        # Use model_construct to bypass Pydantic validation for mocks
+        return EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=settings,
+            workflow_backend=workflow_backend,
+            _working_memory=[],
+            _conflicts={},
         )
 
     @pytest.mark.asyncio
@@ -249,10 +255,16 @@ class TestExtractionIntegration:
         embedder.embed_batch = AsyncMock(side_effect=lambda texts: [[0.1, 0.2, 0.3] for _ in texts])
 
         settings = Settings(openai_api_key="sk-test-dummy")
-        return EngramService(
+        workflow_backend = AsyncMock()
+
+        # Use model_construct to bypass Pydantic validation for mocks
+        return EngramService.model_construct(
             storage=storage,
             embedder=embedder,
             settings=settings,
+            workflow_backend=workflow_backend,
+            _working_memory=[],
+            _conflicts={},
         )
 
     @pytest.mark.asyncio
@@ -713,10 +725,14 @@ class TestBiTemporalRecall:
         """Test that recall_at filters memories by the as_of timestamp."""
         from datetime import datetime, timedelta
 
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=Settings(_env_file=None),
+            workflow_backend=AsyncMock(),
+            _working_memory=[],
+            _conflicts={},
         )
 
         now = datetime.now()
@@ -737,10 +753,14 @@ class TestBiTemporalRecall:
         """Test that recall_at with future timestamp returns all memories."""
         from datetime import datetime, timedelta
 
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=Settings(_env_file=None),
+            workflow_backend=AsyncMock(),
+            _working_memory=[],
+            _conflicts={},
         )
 
         # Query as of tomorrow (should get both)
@@ -762,10 +782,14 @@ class TestBiTemporalRecall:
         """Test that recall_at does NOT include working memory (by design)."""
         from datetime import datetime
 
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=Settings(_env_file=None),
+            workflow_backend=AsyncMock(),
+            _working_memory=[],
+            _conflicts={},
         )
 
         # recall_at should not have include_working parameter - it's bi-temporal
@@ -840,10 +864,14 @@ class TestVerifyWorkflow:
     @pytest.mark.asyncio
     async def test_verify_structured_success(self, mock_storage, mock_embedder):
         """Test verifying a structured memory traces back to its source episode."""
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=Settings(_env_file=None),
+            workflow_backend=AsyncMock(),
+            _working_memory=[],
+            _conflicts={},
         )
 
         # Encode an email to get structured memory
@@ -872,10 +900,14 @@ class TestVerifyWorkflow:
         """Test verify raises NotFoundError for non-existent structured memory."""
         from engram.exceptions import NotFoundError
 
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=Settings(_env_file=None),
+            workflow_backend=AsyncMock(),
+            _working_memory=[],
+            _conflicts={},
         )
 
         with pytest.raises(NotFoundError, match="StructuredMemory not found"):
@@ -886,10 +918,14 @@ class TestVerifyWorkflow:
         """Test verify raises ValidationError for invalid memory ID format."""
         from engram.exceptions import ValidationError
 
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=Settings(_env_file=None),
+            workflow_backend=AsyncMock(),
+            _working_memory=[],
+            _conflicts={},
         )
 
         with pytest.raises(ValidationError, match="Cannot determine memory type"):
@@ -968,10 +1004,14 @@ class TestFreshnessHints:
         """Test that recall returns staleness information for memories."""
         from engram.models import Staleness
 
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=Settings(_env_file=None),
+            workflow_backend=AsyncMock(),
+            _working_memory=[],
+            _conflicts={},
         )
 
         # Encode a message
@@ -1004,10 +1044,14 @@ class TestFreshnessHints:
     async def test_recall_returns_different_memory_types(self, mock_storage, mock_embedder):
         """Test that recall returns multiple memory types."""
 
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=Settings(_env_file=None),
+            workflow_backend=AsyncMock(),
+            _working_memory=[],
+            _conflicts={},
         )
 
         # Encode a message
@@ -1034,10 +1078,14 @@ class TestFreshnessHints:
     @pytest.mark.asyncio
     async def test_working_memory_included_in_recall(self, mock_storage, mock_embedder):
         """Test that working memory is included in recall results."""
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=Settings(_env_file=None),
+            workflow_backend=AsyncMock(),
+            _working_memory=[],
+            _conflicts={},
         )
 
         # Encode a message (adds to working memory)
@@ -1059,10 +1107,14 @@ class TestFreshnessHints:
     @pytest.mark.asyncio
     async def test_recall_freshness_modes(self, mock_storage, mock_embedder):
         """Test that freshness modes work as expected."""
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=mock_storage,
             embedder=mock_embedder,
             settings=Settings(_env_file=None),
+            workflow_backend=AsyncMock(),
+            _working_memory=[],
+            _conflicts={},
         )
 
         # Encode a message

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -166,11 +166,16 @@ class TestGetProvenance:
         embedder = AsyncMock()
         embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
         settings = Settings(openai_api_key="sk-test-dummy-key")
+        workflow_backend = AsyncMock()
 
-        return EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        return EngramService.model_construct(
             storage=storage,
             embedder=embedder,
             settings=settings,
+            workflow_backend=workflow_backend,
+            _working_memory=[],
+            _conflicts={},
         )
 
     @pytest.mark.asyncio
@@ -312,11 +317,16 @@ class TestProvenanceTimeline:
         embedder = AsyncMock()
         embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
         settings = Settings(openai_api_key="sk-test-dummy-key")
+        workflow_backend = AsyncMock()
 
-        return EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        return EngramService.model_construct(
             storage=storage,
             embedder=embedder,
             settings=settings,
+            workflow_backend=workflow_backend,
+            _working_memory=[],
+            _conflicts={},
         )
 
     @pytest.mark.asyncio

--- a/tests/test_recall_behavior.py
+++ b/tests/test_recall_behavior.py
@@ -35,11 +35,16 @@ class TestNegationFiltering:
         embedder.embed_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
 
         settings = Settings(openai_api_key="sk-test-dummy-key")
+        workflow_backend = AsyncMock()
 
-        service = EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        service = EngramService.model_construct(
             storage=storage,
             embedder=embedder,
             settings=settings,
+            workflow_backend=workflow_backend,
+            _working_memory=[],
+            _conflicts={},
         )
         return service
 
@@ -186,11 +191,16 @@ class TestNoBackfillBehavior:
         embedder.embed_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
 
         settings = Settings(openai_api_key="sk-test-dummy-key")
+        workflow_backend = AsyncMock()
 
-        return EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        return EngramService.model_construct(
             storage=storage,
             embedder=embedder,
             settings=settings,
+            workflow_backend=workflow_backend,
+            _working_memory=[],
+            _conflicts={},
         )
 
     @pytest.mark.asyncio
@@ -327,11 +337,16 @@ class TestSourceEpisodeLinkage:
         embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
 
         settings = Settings(openai_api_key="sk-test-dummy-key")
+        workflow_backend = AsyncMock()
 
-        return EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        return EngramService.model_construct(
             storage=storage,
             embedder=embedder,
             settings=settings,
+            workflow_backend=workflow_backend,
+            _working_memory=[],
+            _conflicts={},
         )
 
     @pytest.mark.asyncio
@@ -436,11 +451,16 @@ class TestMultiTenancy:
         embedder.embed_batch = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
 
         settings = Settings(openai_api_key="sk-test-dummy-key")
+        workflow_backend = AsyncMock()
 
-        return EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        return EngramService.model_construct(
             storage=storage,
             embedder=embedder,
             settings=settings,
+            workflow_backend=workflow_backend,
+            _working_memory=[],
+            _conflicts={},
         )
 
     @pytest.mark.asyncio
@@ -558,11 +578,16 @@ class TestFreshnessFiltering:
         embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
 
         settings = Settings(openai_api_key="sk-test-dummy-key")
+        workflow_backend = AsyncMock()
 
-        return EngramService(
+        # Use model_construct to bypass Pydantic validation for mocks
+        return EngramService.model_construct(
             storage=storage,
             embedder=embedder,
             settings=settings,
+            workflow_backend=workflow_backend,
+            _working_memory=[],
+            _conflicts={},
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Enable auth by default in production (#151) - adds environment-based configuration with fail-fast validation
- Eliminate global mutable state in auth (#154) - replaces globals with `@lru_cache` singleton pattern
- Convert EngramService from dataclass to Pydantic (#155) - uses `BaseModel` with proper validation

## Changes

### Security: Enable auth by default (#151)
- Add `env` field to Settings (development/production/test)
- Auth enabled by default when `ENGRAM_ENV=production`
- Fail-fast validation rejects default secret key in production
- Warning when auth explicitly disabled in production

### Refactor: Eliminate global state (#154)
- Replace `_token_validator` and `_rate_limiter` globals with `@lru_cache` functions
- Thread-safe singleton pattern with `cache_clear()` for testing
- Rename `reset_rate_limiter()` to `reset_auth_singletons()`

### Refactor: Convert to Pydantic (#155)
- `EngramService` now extends `BaseModel` with `ConfigDict(arbitrary_types_allowed=True)`
- Convert `__post_init__` to `@model_validator(mode="after")`
- Use `PrivateAttr` for `_working_memory` and `_conflicts`
- Update tests to use `model_construct()` for mock compatibility

## Test plan
- [x] All 866 tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] Pre-commit hooks pass

## Related Issues
Closes #151, closes #154, closes #155

Remaining issues for follow-up PRs:
- #152: Implement distributed rate limiting (requires Redis)
- #153: Remove hardcoded 10k limit (requires pagination changes)