### PR TITLE
feat: implement distributed rate limiting with Redis (#152)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ prefect = ["prefect>=2.0"]
 # MCP server for Claude Code integration
 mcp = ["mcp>=1.2.0"]
 
+# Distributed rate limiting
+redis = ["redis>=5.0"]
+
 # All providers
 all = [
     "anthropic>=0.18",

--- a/src/engram/config.py
+++ b/src/engram/config.py
@@ -399,6 +399,11 @@ class Settings(BaseSettings):
         ge=1,
         description="Default rate limit per minute for other endpoints",
     )
+    rate_limit_redis_url: str | None = Field(
+        default=None,
+        description="Redis URL for distributed rate limiting (e.g., redis://localhost:6379). "
+        "If not set, uses in-memory rate limiting (not suitable for multi-instance deployments).",
+    )
 
     # Batch Operations
     batch_encode_max_items: int = Field(

--- a/uv.lock
+++ b/uv.lock
@@ -1005,6 +1005,9 @@ mcp = [
 prefect = [
     { name = "prefect" },
 ]
+redis = [
+    { name = "redis" },
+]
 sentence-transformers = [
     { name = "sentence-transformers" },
 ]
@@ -1050,6 +1053,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "python-stdnum", specifier = ">=2.2" },
     { name = "qdrant-client", specifier = ">=1.7" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2" },
     { name = "sentence-transformers", marker = "extra == 'all'", specifier = ">=2.3" },
     { name = "sentence-transformers", marker = "extra == 'sentence-transformers'", specifier = ">=2.3" },
@@ -1058,7 +1062,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.20" },
     { name = "validators", specifier = ">=0.20" },
 ]
-provides-extras = ["dev", "demo", "anthropic", "google", "groq", "cohere", "sentence-transformers", "prefect", "mcp", "all"]
+provides-extras = ["dev", "demo", "anthropic", "google", "groq", "cohere", "sentence-transformers", "prefect", "mcp", "redis", "all"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pre-commit", specifier = ">=4.5.1" }]


### PR DESCRIPTION
## Summary
- Add Redis as optional dependency (`uv sync --extra redis`)
- Create abstract `RateLimiter` base class for pluggable rate limiting backends
- Implement `RedisRateLimiter` using sorted sets for sliding window algorithm
- Add `ENGRAM_RATE_LIMIT_REDIS_URL` config option to select backend
- Update `get_rate_limiter()` factory to choose implementation based on config

## Changes
- **pyproject.toml**: Add `redis = ["redis>=5.0"]` optional dependency
- **src/engram/config.py**: Add `rate_limit_redis_url` setting
- **src/engram/api/auth.py**: 
  - Add `REDIS_AVAILABLE` check for optional import
  - Create abstract `RateLimiter(ABC)` base class
  - Rename existing implementation to `InMemoryRateLimiter`
  - Add `RedisRateLimiter` with atomic sorted set operations
  - Update factory to select backend based on config
- **tests/test_auth.py**: 
  - Update imports for renamed class
  - Add tests for factory function behavior
  - Add `TestRedisRateLimiter` with proper skip handling

## Usage
```bash
# Install Redis dependency
uv sync --extra redis

# In-memory (default, single instance only)
uv run engram

# Distributed (multi-instance deployments)
ENGRAM_RATE_LIMIT_REDIS_URL=redis://localhost:6379 uv run engram
```

## Test plan
- [x] All existing tests pass (871 passed)
- [x] New Redis tests skip gracefully when Redis not available (5 skipped)
- [x] Pre-commit hooks pass (ruff, mypy, formatting)

Fixes #152