### PR TITLE
feat: make storage scroll limit configurable (#153)

### DIFF
--- a/src/engram/config.py
+++ b/src/engram/config.py
@@ -408,6 +408,19 @@ class Settings(BaseSettings):
         description="Maximum items allowed in a single batch encode request",
     )
 
+    # Storage Pagination
+    storage_max_scroll_limit: int = Field(
+        default=10000,
+        ge=100,
+        le=100000,
+        description=(
+            "Maximum records to fetch in a single scroll operation. "
+            "This affects memory usage for list operations across collections. "
+            "For users with very large memory stores (>10k per collection), "
+            "reduce this limit to prevent OOM issues."
+        ),
+    )
+
     model_config = {
         "env_prefix": "ENGRAM_",
         "env_file": ".env",

--- a/src/engram/storage/crud.py
+++ b/src/engram/storage/crud.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from qdrant_client import models
 
+from engram.config import settings
+
 if TYPE_CHECKING:
     from engram.models import (
         AuditEntry,
@@ -274,7 +276,7 @@ class CRUDMixin:
                     ),
                 ]
             ),
-            limit=10000,
+            limit=settings.storage_max_scroll_limit,
             with_payload=True,
             with_vectors=True,
         )
@@ -321,7 +323,7 @@ class CRUDMixin:
                     ),
                 ]
             ),
-            limit=10000,
+            limit=settings.storage_max_scroll_limit,
             with_payload=True,
             with_vectors=True,
         )
@@ -1480,7 +1482,7 @@ class CRUDMixin:
         results, _ = await self.client.scroll(
             collection_name=collection,
             scroll_filter=models.Filter(must=filters),
-            limit=10000,  # Fetch all, filter/paginate in Python
+            limit=settings.storage_max_scroll_limit,  # Configurable via ENGRAM_STORAGE_MAX_SCROLL_LIMIT
             with_payload=True,
             with_vectors=False,
         )
@@ -1543,7 +1545,7 @@ class CRUDMixin:
         results, _ = await self.client.scroll(
             collection_name=collection,
             scroll_filter=models.Filter(must=filters),
-            limit=10000,
+            limit=settings.storage_max_scroll_limit,
             with_payload=True,
             with_vectors=False,
         )
@@ -1618,7 +1620,7 @@ class CRUDMixin:
         results, _ = await self.client.scroll(
             collection_name=collection,
             scroll_filter=models.Filter(must=filters),
-            limit=10000,
+            limit=settings.storage_max_scroll_limit,
             with_payload=True,
             with_vectors=False,
         )
@@ -1685,7 +1687,7 @@ class CRUDMixin:
         results, _ = await self.client.scroll(
             collection_name=collection,
             scroll_filter=models.Filter(must=filters),
-            limit=10000,
+            limit=settings.storage_max_scroll_limit,
             with_payload=True,
             with_vectors=False,
         )
@@ -1762,7 +1764,7 @@ class CRUDMixin:
         results, _ = await self.client.scroll(
             collection_name=collection,
             scroll_filter=models.Filter(must=filters),
-            limit=10000,
+            limit=settings.storage_max_scroll_limit,
             with_payload=True,
             with_vectors=False,
         )
@@ -1837,7 +1839,7 @@ class CRUDMixin:
         results, _ = await self.client.scroll(
             collection_name=collection,
             scroll_filter=models.Filter(must=filters),
-            limit=10000,
+            limit=settings.storage_max_scroll_limit,
             with_payload=True,
             with_vectors=True,
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,3 +218,33 @@ class TestSecuritySettings:
         """Test environment should disable auth by default."""
         settings = Settings(env="test", _env_file=None)
         assert settings.is_auth_enabled is False
+
+
+class TestStorageSettings:
+    """Tests for storage-related settings."""
+
+    def test_storage_max_scroll_limit_default(self):
+        """Default scroll limit should be 10000."""
+        settings = Settings(_env_file=None)
+        assert settings.storage_max_scroll_limit == 10000
+
+    def test_storage_max_scroll_limit_custom(self):
+        """Custom scroll limit should be accepted."""
+        settings = Settings(storage_max_scroll_limit=5000, _env_file=None)
+        assert settings.storage_max_scroll_limit == 5000
+
+    def test_storage_max_scroll_limit_bounds(self):
+        """Scroll limit must be between 100 and 100000."""
+        # Test lower bound
+        with pytest.raises(ValidationError):
+            Settings(storage_max_scroll_limit=50, _env_file=None)
+
+        # Test upper bound
+        with pytest.raises(ValidationError):
+            Settings(storage_max_scroll_limit=200000, _env_file=None)
+
+    def test_storage_max_scroll_limit_from_env(self):
+        """ENGRAM_STORAGE_MAX_SCROLL_LIMIT should override default."""
+        with patch.dict(os.environ, {"ENGRAM_STORAGE_MAX_SCROLL_LIMIT": "2500"}):
+            settings = Settings()
+            assert settings.storage_max_scroll_limit == 2500


### PR DESCRIPTION
## Summary
- Add `ENGRAM_STORAGE_MAX_SCROLL_LIMIT` setting (default 10000, range 100-100000)
- Replace all hardcoded 10000 limits in `storage/crud.py` with configurable value
- Allows users with large memory stores to reduce limit to prevent OOM issues
- Allows users with smaller stores to reduce limit for faster operations

## Changes
- **src/engram/config.py**: Add `storage_max_scroll_limit` setting with bounds validation
- **src/engram/storage/crud.py**: 
  - Import settings module
  - Replace 8 hardcoded `limit=10000` with `limit=settings.storage_max_scroll_limit`
- **tests/test_config.py**: Add `TestStorageSettings` class with tests for:
  - Default value (10000)
  - Custom values
  - Bounds validation (100-100000)
  - Environment variable override

## Usage
```bash
# Default (10000 records per scroll)
uv run engram

# Lower limit for memory-constrained environments
ENGRAM_STORAGE_MAX_SCROLL_LIMIT=1000 uv run engram

# Higher limit for large-memory systems with big stores
ENGRAM_STORAGE_MAX_SCROLL_LIMIT=50000 uv run engram
```

## Test plan
- [x] All 870 tests pass (866 existing + 4 new)
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] Environment variable override works

## Note on acceptance criteria
This PR addresses the "no hardcoded limits" criterion by making the limit configurable. The issue also mentions cursor-based pagination, which would be a larger architectural change requiring rework of how `search_memories` combines results from multiple collections. That work could be done in a follow-up PR if needed.

Fixes #153 (partially - configurable limits implemented)