### PR TITLE
fix: systematic codebase improvements (#166, #168, #169, #171, #173)

### DIFF
--- a/src/engram/api/app.py
+++ b/src/engram/api/app.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from engram.config import Settings
@@ -78,6 +79,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # Run with: uvicorn engram.api:app --reload
         ```
     """
+    if settings is None:
+        settings = Settings()
+
     app = FastAPI(
         title="Engram",
         description="Memory you can trust. A memory system for AI applications.",
@@ -86,6 +90,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         docs_url="/docs",
         redoc_url="/redoc",
     )
+
+    # Add CORS middleware if enabled
+    if settings.cors_enabled:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=settings.cors_allow_origins,
+            allow_credentials=settings.cors_allow_credentials,
+            allow_methods=settings.cors_allow_methods,
+            allow_headers=settings.cors_allow_headers,
+            max_age=settings.cors_max_age,
+        )
 
     # Register exception handlers
     @app.exception_handler(ValidationError)

--- a/src/engram/config.py
+++ b/src/engram/config.py
@@ -475,6 +475,63 @@ class Settings(BaseSettings):
         ),
     )
 
+    # CORS Configuration
+    cors_enabled: bool = Field(
+        default=True,
+        description="Enable CORS middleware",
+    )
+    cors_allow_origins: list[str] = Field(
+        default_factory=lambda: ["*"],
+        description=(
+            "List of allowed CORS origins. Use ['*'] for permissive mode (dev only). "
+            "In production, specify exact origins like ['https://app.example.com']."
+        ),
+    )
+    cors_allow_methods: list[str] = Field(
+        default_factory=lambda: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+        description="Allowed HTTP methods for CORS requests",
+    )
+    cors_allow_headers: list[str] = Field(
+        default_factory=lambda: ["*"],
+        description="Allowed headers for CORS requests",
+    )
+    cors_allow_credentials: bool = Field(
+        default=False,
+        description=(
+            "Allow credentials (cookies, auth headers) in CORS requests. "
+            "Cannot be True when cors_allow_origins is ['*']."
+        ),
+    )
+    cors_max_age: int = Field(
+        default=600,
+        ge=0,
+        le=86400,
+        description="Max age (seconds) for CORS preflight cache",
+    )
+
+    # Phone Extraction Configuration
+    phone_default_region: str = Field(
+        default="US",
+        min_length=2,
+        max_length=2,
+        description=(
+            "Default region for phone number parsing (ISO 3166-1 alpha-2 code). "
+            "Used when parsing numbers without country codes."
+        ),
+    )
+
+    # Working Memory Configuration
+    working_memory_max_size: int = Field(
+        default=1000,
+        ge=10,
+        le=10000,
+        description=(
+            "Maximum number of episodes to keep in working memory. "
+            "When exceeded, oldest episodes are evicted (FIFO). "
+            "Prevents unbounded memory growth in long sessions."
+        ),
+    )
+
     model_config = {
         "env_prefix": "ENGRAM_",
         "env_file": ".env",

--- a/src/engram/extraction/phone.py
+++ b/src/engram/extraction/phone.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import phonenumbers
 from phonenumbers import Leniency, PhoneNumberFormat
 
+from engram.config import settings
 from engram.models import Episode
 
 from .base import Extractor
@@ -31,14 +32,15 @@ class PhoneExtractor(Extractor):
 
     name: str = "phone"
 
-    def __init__(self, default_region: str = "US") -> None:
+    def __init__(self, default_region: str | None = None) -> None:
         """Initialize phone extractor.
 
         Args:
             default_region: Default region for parsing numbers without country code.
                            Uses ISO 3166-1 alpha-2 codes (e.g., "US", "GB", "DE").
+                           If not provided, uses ENGRAM_PHONE_DEFAULT_REGION setting.
         """
-        self.default_region = default_region
+        self.default_region = default_region or settings.phone_default_region
 
     def extract(self, episode: Episode) -> list[str]:
         """Extract phone numbers from episode content.


### PR DESCRIPTION
## Summary

Addresses multiple GitHub issues identified during code review:

- **#166** - Convert `ScoredResult` from dataclass to Pydantic
- **#168** - Handle collection creation race condition  
- **#169** - Add working memory size limit
- **#171** - Make phone region configurable
- **#173** - Add CORS middleware configuration

## Changes

### #166 - ScoredResult Pydantic Conversion
- Replace `@dataclass` with `BaseModel` for consistency with project standards
- Add `ConfigDict(arbitrary_types_allowed=True)` for generic type support
- Remove strict score bounds (vector DBs can return values like `1.0000000051` due to floating-point precision)

### #168 - Collection Race Condition
- Refactor `_ensure_collections()` to handle concurrent initialization
- Catch "already exists" errors gracefully when multiple instances start simultaneously
- Log debug message when race condition is detected

### #169 - Working Memory Size Limit
- Add `working_memory_max_size` setting (default: 1000, range: 10-10000)
- Implement FIFO eviction in `_enforce_working_memory_limit()`
- Prevents unbounded memory growth in long sessions

### #171 - Configurable Phone Region
- Add `phone_default_region` setting (ISO 3166-1 alpha-2 code, default: "US")
- Update `PhoneExtractor` to use `settings.phone_default_region`
- Allows non-US deployments to configure default region for phone parsing

### #173 - CORS Middleware
- Add settings: `cors_enabled`, `cors_allow_origins`, `cors_allow_methods`, `cors_allow_headers`, `cors_allow_credentials`, `cors_max_age`
- Configure CORS middleware in `create_app()` when enabled
- Sensible defaults: enabled, allow all origins (for development)

## Test Plan
- [x] All 895 existing tests pass
- [x] New tests added for working memory limit (4 tests)
- [x] New tests added for CORS settings (7 tests)
- [x] New tests added for phone settings (4 tests)
- [x] New tests added for working memory settings (4 tests)
- [x] mypy passes with no issues
- [x] ruff check and format pass