### PR TITLE
refactor: use app.state for service dependency injection

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -346,13 +346,12 @@ class TestAPIIntegration:
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
 
-        from engram.api.router import router, set_service
+        from engram.api.router import router
 
         app = FastAPI()
         app.include_router(router, prefix="/api/v1")
-        set_service(mock_service)
-        yield TestClient(app)
-        set_service(None)  # type: ignore[arg-type]
+        app.state.service = mock_service
+        return TestClient(app)
 
     def test_full_encode_recall_via_api(self, client, mock_service):
         """Test encode and recall via REST API."""


### PR DESCRIPTION
## Summary
- Replace module-level global `_service` state with FastAPI's recommended `app.state` pattern
- Cleaner dependency injection that supports multiple app instances
- Better testability since each app instance is independent

## Changes
- **router.py**: Remove `set_service()` function and global `_service` variable. `get_service()` now accesses `request.app.state.service`
- **app.py**: Store service on `app.state.service` instead of calling `set_service()`
- **tests**: Add `create_test_app()` helper, update all fixtures to use `app.state.service`

## Why This Pattern?
The previous approach used module-level global state:
```python
_service: EngramService | None = None

def set_service(service: EngramService) -> None:
    global _service
    _service = service
```

This works but:
- Makes testing harder (must call `set_service()` in fixtures)
- Can cause issues with multiple app instances
- Tests can interfere with each other via shared global state

The new approach uses FastAPI's recommended pattern:
```python
async def get_service(request: Request) -> EngramService:
    service = getattr(request.app.state, "service", None)
    if service is None:
        raise HTTPException(status_code=503, detail="Service not initialized")
    return service
```

## Test plan
- [x] All 924 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] Local examples run successfully
- [x] External quickstart example runs successfully