### PR TITLE
fix: add OperationStatus to distinguish LLM failures from success

### DIFF
--- a/src/engram/linking/__init__.py
+++ b/src/engram/linking/__init__.py
@@ -24,6 +24,7 @@ from .discovery import (
     LinkDiscoveryResult,
     LinkType,
     MemoryEvolution,
+    discover_and_apply_links,
     discover_links,
     evolve_memory,
 )
@@ -34,6 +35,7 @@ __all__ = [
     "LinkDiscoveryResult",
     "LinkType",
     "MemoryEvolution",
+    "discover_and_apply_links",
     "discover_links",
     "evolve_memory",
 ]

--- a/src/engram/models/__init__.py
+++ b/src/engram/models/__init__.py
@@ -19,7 +19,14 @@ Supporting Types:
 """
 
 from .audit import AuditEntry
-from .base import ConfidenceScore, ExtractionMethod, MemoryBase, Staleness, generate_id
+from .base import (
+    ConfidenceScore,
+    ExtractionMethod,
+    MemoryBase,
+    OperationStatus,
+    Staleness,
+    generate_id,
+)
 from .episode import Episode, QuickExtracts
 from .history import ChangeType, HistoryEntry, TriggerType
 from .procedural import ProceduralMemory
@@ -40,6 +47,7 @@ __all__ = [
     "ConfidenceScore",
     "ExtractionMethod",
     "MemoryBase",
+    "OperationStatus",
     "Staleness",
     "generate_id",
     # Memory types

--- a/src/engram/models/base.py
+++ b/src/engram/models/base.py
@@ -22,6 +22,23 @@ class ExtractionMethod(str, Enum):
     INFERRED = "inferred"  # LLM-derived, uncertain (confidence: LLM-assessed)
 
 
+class OperationStatus(str, Enum):
+    """Status of an LLM or async operation.
+
+    Used to distinguish successful results from failures that return
+    degraded/default data. Callers MUST check status before trusting results.
+
+    Values:
+        SUCCESS: Operation completed successfully, results are trustworthy.
+        FAILED: Operation failed, results contain default/fallback values.
+        PARTIAL: Operation partially succeeded, some results may be degraded.
+    """
+
+    SUCCESS = "success"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
 class Staleness(str, Enum):
     """Freshness state of a memory.
 


### PR DESCRIPTION
## Summary

Fixes #172 - LLM error handling returns success with degraded data (silent failures)

### Problem
LLM failures in contradiction detection, query expansion, and link discovery were returning degraded results without any way for callers to distinguish "no conflict found" from "analysis failed". This caused silent failures where the system would proceed as if the LLM had actually analyzed the input.

### Solution
Add `OperationStatus` enum (SUCCESS, FAILED, PARTIAL) to LLM result models:

| Model | Location | Purpose |
|-------|----------|---------|
| `ConflictAnalysis` | `service/contradiction.py` | Conflict detection results |
| `ExpandedQuery` | `service/query_expansion.py` | Query expansion results |
| `LinkDiscoveryResult` | `linking/discovery.py` | Link discovery results |

All models also include `error_message: str | None` for debugging when `status=FAILED`.

### Caller Updates
Callers now check status before trusting results:

- `detect_contradictions()` - Skips failed analyses with warning (doesn't treat as "no conflict")
- `get_combined_embedding()` - Falls back to original embedding on expansion failure
- `discover_and_apply_links()` - Returns 0 when discovery fails (doesn't silently succeed)

## Changes

- **New**: `OperationStatus` enum in `models/base.py`
- **Updated**: `ConflictAnalysis`, `ExpandedQuery`, `LinkDiscoveryResult` models
- **Updated**: Error handlers to set `status=FAILED` and `error_message`
- **Updated**: Callers to check status before trusting results
- **Tests**: 6 new tests for failed status handling

## Test Plan

- [x] All 930 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] New tests verify failed status is returned on LLM error
- [x] New tests verify callers handle failed status correctly