### PR TITLE
fix: add transaction boundaries to encode() for atomic storage operations (#163)

### DIFF
--- a/src/engram/storage/__init__.py
+++ b/src/engram/storage/__init__.py
@@ -16,10 +16,12 @@ Example:
 from .base import COLLECTION_NAMES, DEFAULT_EMBEDDING_DIM
 from .client import EngramStorage
 from .search import ScoredResult
+from .transaction import TransactionContext
 
 __all__ = [
     "EngramStorage",
     "ScoredResult",
+    "TransactionContext",
     "COLLECTION_NAMES",
     "DEFAULT_EMBEDDING_DIM",
 ]

--- a/src/engram/storage/client.py
+++ b/src/engram/storage/client.py
@@ -26,6 +26,7 @@ from .crud import CRUDMixin
 from .history import HistoryMixin
 from .search import SearchMixin
 from .store import StoreMixin
+from .transaction import TransactionMixin
 from .webhook import WebhookMixin
 
 logger = logging.getLogger(__name__)
@@ -58,7 +59,14 @@ class MemoryStats(BaseModel):
 
 
 class EngramStorage(
-    StoreMixin, SearchMixin, CRUDMixin, AuditMixin, HistoryMixin, WebhookMixin, StorageBase
+    StoreMixin,
+    SearchMixin,
+    CRUDMixin,
+    AuditMixin,
+    HistoryMixin,
+    WebhookMixin,
+    TransactionMixin,
+    StorageBase,
 ):
     """Async Qdrant storage client for Engram memories.
 

--- a/src/engram/storage/transaction.py
+++ b/src/engram/storage/transaction.py
@@ -1,0 +1,310 @@
+"""Transaction support for Engram storage.
+
+Provides compensating transaction pattern since Qdrant doesn't support
+native transactions. Tracks operations and rolls back on failure.
+
+Example:
+    ```python
+    async with storage.transaction() as txn:
+        await txn.store_episode(episode)
+        await txn.store_structured(structured)
+        # If any operation fails, previous operations are rolled back
+    ```
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from engram.models import AuditEntry, Episode, StructuredMemory
+    from engram.storage import EngramStorage
+
+logger = logging.getLogger(__name__)
+
+
+class OperationType(str, Enum):
+    """Types of storage operations that can be tracked and rolled back."""
+
+    STORE_EPISODE = "store_episode"
+    STORE_STRUCTURED = "store_structured"
+    UPDATE_EPISODE = "update_episode"
+    LOG_AUDIT = "log_audit"
+
+
+@dataclass
+class TrackedOperation:
+    """A storage operation that can be rolled back.
+
+    Attributes:
+        operation: The type of operation performed.
+        entity_id: The ID of the entity affected.
+        user_id: The user ID for multi-tenancy.
+        original_data: Original data for updates (to restore on rollback).
+    """
+
+    operation: OperationType
+    entity_id: str
+    user_id: str
+    original_data: dict[str, object] | None = None
+
+
+@dataclass
+class TransactionContext:
+    """Context manager for compensating transactions.
+
+    Tracks all storage operations and rolls them back on failure.
+    Since Qdrant doesn't support native transactions, this implements
+    a compensating transaction pattern where:
+    1. Operations are tracked as they execute
+    2. On failure, compensating operations (deletes) undo previous work
+    3. On success, the tracked operations are committed (no-op)
+
+    Note: This provides eventual consistency, not strict ACID.
+    There's a small window where partial data may be visible.
+
+    Attributes:
+        storage: The EngramStorage instance.
+        operations: List of tracked operations for rollback.
+        committed: Whether the transaction has been committed.
+    """
+
+    storage: EngramStorage
+    operations: list[TrackedOperation] = field(default_factory=list)
+    committed: bool = False
+    _original_episode_data: dict[str, dict[str, object]] = field(default_factory=dict)
+
+    async def store_episode(self, episode: Episode) -> str:
+        """Store an episode with transaction tracking.
+
+        Args:
+            episode: The episode to store.
+
+        Returns:
+            The episode ID.
+
+        Raises:
+            Exception: If the storage operation fails.
+        """
+        episode_id = await self.storage.store_episode(episode)
+        self.operations.append(
+            TrackedOperation(
+                operation=OperationType.STORE_EPISODE,
+                entity_id=episode_id,
+                user_id=episode.user_id,
+            )
+        )
+        return episode_id
+
+    async def store_structured(self, memory: StructuredMemory) -> str:
+        """Store a structured memory with transaction tracking.
+
+        Args:
+            memory: The structured memory to store.
+
+        Returns:
+            The memory ID.
+
+        Raises:
+            Exception: If the storage operation fails.
+        """
+        memory_id = await self.storage.store_structured(memory)
+        self.operations.append(
+            TrackedOperation(
+                operation=OperationType.STORE_STRUCTURED,
+                entity_id=memory_id,
+                user_id=memory.user_id,
+            )
+        )
+        return memory_id
+
+    async def update_episode(self, episode: Episode) -> None:
+        """Update an episode with transaction tracking.
+
+        Captures original state for rollback.
+
+        Args:
+            episode: The episode to update.
+
+        Raises:
+            Exception: If the storage operation fails.
+        """
+        # Capture original state if not already captured
+        if episode.id not in self._original_episode_data:
+            original = await self.storage.get_episode(episode.id, episode.user_id)
+            if original:
+                self._original_episode_data[episode.id] = original.model_dump(mode="json")
+
+        await self.storage.update_episode(episode)
+        self.operations.append(
+            TrackedOperation(
+                operation=OperationType.UPDATE_EPISODE,
+                entity_id=episode.id,
+                user_id=episode.user_id,
+                original_data=self._original_episode_data.get(episode.id),
+            )
+        )
+
+    async def log_audit(self, entry: AuditEntry) -> str:
+        """Log an audit entry with transaction tracking.
+
+        Note: Audit entries are typically not rolled back for forensics,
+        but we track them for completeness. On rollback, the audit entry
+        may be marked as rolled_back rather than deleted.
+
+        Args:
+            entry: The audit entry to log.
+
+        Returns:
+            The audit entry ID.
+
+        Raises:
+            Exception: If the storage operation fails.
+        """
+        audit_id = await self.storage.log_audit(entry)
+        self.operations.append(
+            TrackedOperation(
+                operation=OperationType.LOG_AUDIT,
+                entity_id=audit_id,
+                user_id=entry.user_id,
+            )
+        )
+        return audit_id
+
+    async def rollback(self) -> int:
+        """Roll back all tracked operations in reverse order.
+
+        For store operations, deletes the created entities.
+        For update operations, restores the original data.
+
+        Returns:
+            Number of operations rolled back.
+        """
+        rolled_back = 0
+
+        # Roll back in reverse order (LIFO)
+        for op in reversed(self.operations):
+            try:
+                if op.operation == OperationType.STORE_EPISODE:
+                    # delete_episode returns dict with 'deleted' key
+                    result = await self.storage.delete_episode(
+                        episode_id=op.entity_id,
+                        user_id=op.user_id,
+                    )
+                    if result.get("deleted", False):
+                        rolled_back += 1
+                        logger.debug("Rolled back store_episode: %s", op.entity_id)
+
+                elif op.operation == OperationType.STORE_STRUCTURED:
+                    # delete_structured returns bool
+                    deleted = await self.storage.delete_structured(
+                        memory_id=op.entity_id,
+                        user_id=op.user_id,
+                    )
+                    if deleted:
+                        rolled_back += 1
+                        logger.debug("Rolled back store_structured: %s", op.entity_id)
+
+                elif op.operation == OperationType.UPDATE_EPISODE:
+                    if op.original_data:
+                        # Restore original episode data
+                        from engram.models import Episode
+
+                        original_episode = Episode.model_validate(op.original_data)
+                        await self.storage.update_episode(original_episode)
+                        rolled_back += 1
+                        logger.debug("Rolled back update_episode: %s", op.entity_id)
+
+                elif op.operation == OperationType.LOG_AUDIT:
+                    # Don't delete audit entries - they're forensic records
+                    # Instead, log that this was part of a rolled-back transaction
+                    logger.debug(
+                        "Audit entry %s was part of rolled-back transaction",
+                        op.entity_id,
+                    )
+
+            except Exception as e:
+                # Log but continue rolling back other operations
+                logger.error(
+                    "Failed to roll back %s %s: %s",
+                    op.operation.value,
+                    op.entity_id,
+                    e,
+                )
+
+        self.operations.clear()
+        return rolled_back
+
+    def commit(self) -> None:
+        """Mark the transaction as committed.
+
+        After commit, rollback will not be triggered.
+        """
+        self.committed = True
+        self.operations.clear()
+        self._original_episode_data.clear()
+
+    async def __aenter__(self) -> TransactionContext:
+        """Enter the transaction context."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> bool:
+        """Exit the transaction context.
+
+        If an exception occurred and the transaction wasn't committed,
+        rolls back all tracked operations.
+
+        Returns:
+            False to propagate any exception.
+        """
+        if exc_type is not None and not self.committed:
+            logger.warning(
+                "Transaction failed with %s: %s. Rolling back %d operations.",
+                exc_type.__name__,
+                exc_val,
+                len(self.operations),
+            )
+            rolled_back = await self.rollback()
+            logger.info("Rolled back %d operations", rolled_back)
+
+        return False  # Don't suppress exceptions
+
+
+class TransactionMixin:
+    """Mixin that adds transaction support to EngramStorage."""
+
+    def transaction(self) -> TransactionContext:
+        """Create a new transaction context.
+
+        Usage:
+            ```python
+            async with storage.transaction() as txn:
+                await txn.store_episode(episode)
+                await txn.store_structured(structured)
+                txn.commit()  # Optional, auto-commits if no exception
+            ```
+
+        Returns:
+            A TransactionContext for tracking and rolling back operations.
+        """
+        # Type assertion for self as EngramStorage
+        from engram.storage import EngramStorage
+
+        assert isinstance(self, EngramStorage)
+        return TransactionContext(storage=self)
+
+
+__all__ = [
+    "OperationType",
+    "TrackedOperation",
+    "TransactionContext",
+    "TransactionMixin",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,110 @@
+"""Pytest configuration and shared fixtures."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+# Add tests directory to path so utils can be imported
+tests_dir = Path(__file__).parent
+if str(tests_dir) not in sys.path:
+    sys.path.insert(0, str(tests_dir))
+
+if TYPE_CHECKING:
+    pass
+
+
+class MockTransactionContext:
+    """Mock transaction context that delegates to the storage mock.
+
+    This allows tests to use the transaction context pattern without
+    changing the underlying mock storage assertions.
+    """
+
+    def __init__(self, storage: AsyncMock) -> None:
+        """Initialize with a mock storage.
+
+        Args:
+            storage: The mock storage to delegate to.
+        """
+        self._storage = storage
+        self.operations: list = []
+        self.committed = False
+
+    async def store_episode(self, episode):
+        """Delegate to storage.store_episode."""
+        result = await self._storage.store_episode(episode)
+        self.operations.append(("store_episode", episode.id))
+        return result
+
+    async def store_structured(self, memory):
+        """Delegate to storage.store_structured."""
+        result = await self._storage.store_structured(memory)
+        self.operations.append(("store_structured", memory.id))
+        return result
+
+    async def update_episode(self, episode):
+        """Delegate to storage.update_episode."""
+        await self._storage.update_episode(episode)
+        self.operations.append(("update_episode", episode.id))
+
+    async def log_audit(self, entry):
+        """Delegate to storage.log_audit."""
+        result = await self._storage.log_audit(entry)
+        self.operations.append(("log_audit", entry.id))
+        return result
+
+    def commit(self) -> None:
+        """Mark the transaction as committed."""
+        self.committed = True
+        self.operations.clear()
+
+    async def rollback(self) -> int:
+        """Mock rollback - just clear operations."""
+        count = len(self.operations)
+        self.operations.clear()
+        return count
+
+    async def __aenter__(self):
+        """Enter the transaction context."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Exit the transaction context."""
+        if exc_type is not None and not self.committed:
+            await self.rollback()
+        return False
+
+
+def add_transaction_support(storage: AsyncMock) -> AsyncMock:
+    """Add transaction support to a mock storage.
+
+    This makes the storage.transaction() method return a MockTransactionContext
+    that delegates to the underlying storage mock methods.
+
+    Args:
+        storage: The mock storage to enhance.
+
+    Returns:
+        The same storage mock with transaction support added.
+
+    Example:
+        ```python
+        storage = AsyncMock()
+        storage.store_episode = AsyncMock(return_value="ep_123")
+        add_transaction_support(storage)
+
+        # Now can use storage.transaction() as async context manager
+        async with storage.transaction() as txn:
+            await txn.store_episode(episode)
+            txn.commit()
+        ```
+    """
+
+    def create_transaction():
+        return MockTransactionContext(storage)
+
+    storage.transaction = create_transaction
+    return storage

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,6 +10,7 @@ import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from conftest import add_transaction_support
 
 from engram.config import Settings
 from engram.models import Episode, StructuredMemory
@@ -94,6 +95,7 @@ class TestEncodeRecallWorkflow:
         storage.search_structured = AsyncMock(side_effect=search_structured)
         storage.initialize = AsyncMock()
         storage.close = AsyncMock()
+        add_transaction_support(storage)
 
         return storage
 
@@ -249,6 +251,7 @@ class TestExtractionIntegration:
         storage.store_structured = AsyncMock(return_value="struct_123")
         storage.initialize = AsyncMock()
         storage.close = AsyncMock()
+        add_transaction_support(storage)
 
         embedder = AsyncMock()
         embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
@@ -714,9 +717,12 @@ class TestBiTemporalRecall:
         storage.search_episodes = AsyncMock(side_effect=search_episodes)
         storage.search_structured = AsyncMock(side_effect=search_structured)
         storage.log_audit = AsyncMock()
+        storage.update_episode = AsyncMock()
+        storage.get_episode = AsyncMock(return_value=None)
         storage.initialize = AsyncMock()
         storage.close = AsyncMock()
 
+        add_transaction_support(storage)
         return storage
 
     @pytest.mark.asyncio
@@ -854,10 +860,12 @@ class TestVerifyWorkflow:
         storage.store_structured = AsyncMock(side_effect=store_structured)
         storage.get_episode = AsyncMock(side_effect=get_episode)
         storage.get_structured = AsyncMock(side_effect=get_structured)
+        storage.update_episode = AsyncMock()
         storage.log_audit = AsyncMock()
         storage.initialize = AsyncMock()
         storage.close = AsyncMock()
 
+        add_transaction_support(storage)
         return storage
 
     @pytest.mark.asyncio
@@ -995,7 +1003,11 @@ class TestFreshnessHints:
         storage.search_structured = AsyncMock(side_effect=search_structured)
         storage.search_semantic = AsyncMock(side_effect=search_semantic)
         storage.search_procedural = AsyncMock(side_effect=search_procedural)
+        storage.update_episode = AsyncMock()
+        storage.get_episode = AsyncMock(return_value=None)
         storage.log_audit = AsyncMock()
+
+        add_transaction_support(storage)
         return storage
 
     @pytest.mark.asyncio

--- a/tests/test_recall_behavior.py
+++ b/tests/test_recall_behavior.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from conftest import add_transaction_support
 
 from engram.config import Settings
 from engram.models import (
@@ -452,6 +453,11 @@ class TestMultiTenancy:
 
         settings = Settings(openai_api_key="sk-test-dummy-key")
         workflow_backend = AsyncMock()
+
+        # Add transaction support for encode() calls
+        storage.update_episode = AsyncMock()
+        storage.get_episode = AsyncMock(return_value=None)
+        add_transaction_support(storage)
 
         # Use model_construct to bypass Pydantic validation for mocks
         return EngramService.model_construct(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from conftest import add_transaction_support
 
 from engram.config import Settings
 from engram.models import (
@@ -71,6 +72,7 @@ class TestEngramServiceEncode:
         storage.update_episode = AsyncMock()
         storage.store_structured = AsyncMock(return_value="struct_123")
         storage.log_audit = AsyncMock()
+        add_transaction_support(storage)
 
         embedder = AsyncMock()
         embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
@@ -687,6 +689,7 @@ class TestWorkingMemory:
         storage.search_semantic.return_value = []
         storage.search_procedural.return_value = []
         storage.list_structured_memories.return_value = []
+        add_transaction_support(storage)
 
         embedder = AsyncMock()
         embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])
@@ -1096,6 +1099,7 @@ class TestWorkingMemoryLimit:
         storage.store_structured = AsyncMock(return_value="struct_123")
         storage.log_audit = AsyncMock()
         storage.search_episodes.return_value = []
+        add_transaction_support(storage)
 
         embedder = AsyncMock()
         embedder.embed = AsyncMock(return_value=[0.1, 0.2, 0.3])

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -1,0 +1,320 @@
+"""Tests for storage transaction support."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from engram.models import AuditEntry, Episode, StructuredMemory
+from engram.storage.transaction import (
+    OperationType,
+    TrackedOperation,
+    TransactionContext,
+)
+
+
+def create_mock_storage() -> MagicMock:
+    """Create a mock EngramStorage with all required methods."""
+    storage = MagicMock()
+    storage.store_episode = AsyncMock(return_value="ep_123")
+    storage.store_structured = AsyncMock(return_value="struct_456")
+    storage.update_episode = AsyncMock()
+    storage.log_audit = AsyncMock(return_value="audit_789")
+    storage.get_episode = AsyncMock(return_value=None)
+    storage.delete_episode = AsyncMock(return_value={"deleted": True})
+    storage.delete_structured = AsyncMock(return_value=True)
+    return storage
+
+
+def create_test_episode() -> Episode:
+    """Create a test episode."""
+    return Episode(
+        id="ep_test",
+        content="Test content",
+        role="user",
+        user_id="user_1",
+        embedding=[0.1] * 1536,
+    )
+
+
+def create_test_structured() -> StructuredMemory:
+    """Create a test structured memory."""
+    return StructuredMemory(
+        id="struct_test",
+        source_episode_id="ep_test",
+        user_id="user_1",
+        embedding=[0.1] * 1536,
+    )
+
+
+def create_test_audit() -> AuditEntry:
+    """Create a test audit entry."""
+    return AuditEntry.for_encode(
+        user_id="user_1",
+        episode_id="ep_test",
+        facts_count=3,
+    )
+
+
+class TestTrackedOperation:
+    """Tests for TrackedOperation dataclass."""
+
+    def test_create_store_operation(self) -> None:
+        """Should create a tracked store operation."""
+        op = TrackedOperation(
+            operation=OperationType.STORE_EPISODE,
+            entity_id="ep_123",
+            user_id="user_1",
+        )
+        assert op.operation == OperationType.STORE_EPISODE
+        assert op.entity_id == "ep_123"
+        assert op.user_id == "user_1"
+        assert op.original_data is None
+
+    def test_create_update_operation_with_original(self) -> None:
+        """Should create a tracked update operation with original data."""
+        original = {"id": "ep_123", "content": "original"}
+        op = TrackedOperation(
+            operation=OperationType.UPDATE_EPISODE,
+            entity_id="ep_123",
+            user_id="user_1",
+            original_data=original,
+        )
+        assert op.original_data == original
+
+
+class TestTransactionContext:
+    """Tests for TransactionContext."""
+
+    @pytest.mark.asyncio
+    async def test_store_episode_tracks_operation(self) -> None:
+        """store_episode should track the operation for rollback."""
+        storage = create_mock_storage()
+        episode = create_test_episode()
+
+        async with TransactionContext(storage=storage) as txn:
+            await txn.store_episode(episode)
+            assert len(txn.operations) == 1
+            assert txn.operations[0].operation == OperationType.STORE_EPISODE
+            txn.commit()
+
+        storage.store_episode.assert_called_once_with(episode)
+
+    @pytest.mark.asyncio
+    async def test_store_structured_tracks_operation(self) -> None:
+        """store_structured should track the operation for rollback."""
+        storage = create_mock_storage()
+        structured = create_test_structured()
+
+        async with TransactionContext(storage=storage) as txn:
+            await txn.store_structured(structured)
+            assert len(txn.operations) == 1
+            assert txn.operations[0].operation == OperationType.STORE_STRUCTURED
+            txn.commit()
+
+        storage.store_structured.assert_called_once_with(structured)
+
+    @pytest.mark.asyncio
+    async def test_update_episode_captures_original(self) -> None:
+        """update_episode should capture original state for rollback."""
+        storage = create_mock_storage()
+        original_episode = create_test_episode()
+        original_episode.id = "ep_original"
+        storage.get_episode = AsyncMock(return_value=original_episode)
+
+        episode = create_test_episode()
+        episode.id = "ep_original"
+        episode.content = "updated content"
+
+        async with TransactionContext(storage=storage) as txn:
+            await txn.update_episode(episode)
+            assert len(txn.operations) == 1
+            assert txn.operations[0].operation == OperationType.UPDATE_EPISODE
+            assert txn.operations[0].original_data is not None
+            txn.commit()
+
+        storage.get_episode.assert_called_once_with("ep_original", episode.user_id)
+        storage.update_episode.assert_called_once_with(episode)
+
+    @pytest.mark.asyncio
+    async def test_log_audit_tracks_operation(self) -> None:
+        """log_audit should track the operation."""
+        storage = create_mock_storage()
+        audit = create_test_audit()
+
+        async with TransactionContext(storage=storage) as txn:
+            await txn.log_audit(audit)
+            assert len(txn.operations) == 1
+            assert txn.operations[0].operation == OperationType.LOG_AUDIT
+            txn.commit()
+
+        storage.log_audit.assert_called_once_with(audit)
+
+    @pytest.mark.asyncio
+    async def test_commit_clears_operations(self) -> None:
+        """commit should clear tracked operations."""
+        storage = create_mock_storage()
+        episode = create_test_episode()
+
+        txn = TransactionContext(storage=storage)
+        await txn.store_episode(episode)
+        assert len(txn.operations) == 1
+
+        txn.commit()
+        assert len(txn.operations) == 0
+        assert txn.committed is True
+
+    @pytest.mark.asyncio
+    async def test_rollback_deletes_stored_entities(self) -> None:
+        """rollback should delete stored episode and structured memory."""
+        storage = create_mock_storage()
+        episode = create_test_episode()
+        structured = create_test_structured()
+
+        txn = TransactionContext(storage=storage)
+        await txn.store_episode(episode)
+        await txn.store_structured(structured)
+
+        rolled_back = await txn.rollback()
+
+        assert rolled_back == 2
+        storage.delete_episode.assert_called_once()
+        storage.delete_structured.assert_called_once()
+        assert len(txn.operations) == 0
+
+    @pytest.mark.asyncio
+    async def test_rollback_restores_updated_episode(self) -> None:
+        """rollback should restore original episode data."""
+        storage = create_mock_storage()
+        original_episode = create_test_episode()
+        original_episode.id = "ep_restore"
+        original_episode.content = "original content"
+        storage.get_episode = AsyncMock(return_value=original_episode)
+
+        episode = create_test_episode()
+        episode.id = "ep_restore"
+        episode.content = "updated content"
+
+        txn = TransactionContext(storage=storage)
+        await txn.update_episode(episode)
+
+        rolled_back = await txn.rollback()
+
+        assert rolled_back == 1
+        # update_episode should be called twice: once for the update, once for restore
+        assert storage.update_episode.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_context_manager_rollback_on_exception(self) -> None:
+        """Context manager should rollback on exception."""
+        storage = create_mock_storage()
+        episode = create_test_episode()
+
+        with pytest.raises(ValueError, match="intentional"):
+            async with TransactionContext(storage=storage) as txn:
+                await txn.store_episode(episode)
+                raise ValueError("intentional error")
+
+        # Should have attempted to delete the stored episode
+        storage.delete_episode.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_context_manager_no_rollback_on_commit(self) -> None:
+        """Context manager should not rollback if committed."""
+        storage = create_mock_storage()
+        episode = create_test_episode()
+
+        async with TransactionContext(storage=storage) as txn:
+            await txn.store_episode(episode)
+            txn.commit()
+
+        # Should not have attempted to delete
+        storage.delete_episode.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rollback_order_is_lifo(self) -> None:
+        """Rollback should happen in reverse order (LIFO)."""
+        storage = create_mock_storage()
+        call_order: list[str] = []
+
+        async def track_delete_episode(*args, **kwargs) -> dict[str, bool]:
+            call_order.append("episode")
+            return {"deleted": True}
+
+        async def track_delete_structured(*args, **kwargs) -> bool:
+            call_order.append("structured")
+            return True
+
+        storage.delete_episode = AsyncMock(side_effect=track_delete_episode)
+        storage.delete_structured = AsyncMock(side_effect=track_delete_structured)
+
+        episode = create_test_episode()
+        structured = create_test_structured()
+
+        txn = TransactionContext(storage=storage)
+        await txn.store_episode(episode)  # First
+        await txn.store_structured(structured)  # Second
+
+        await txn.rollback()
+
+        # Structured should be rolled back first (LIFO)
+        assert call_order == ["structured", "episode"]
+
+    @pytest.mark.asyncio
+    async def test_rollback_continues_on_individual_failure(self) -> None:
+        """Rollback should continue even if one operation fails."""
+        storage = create_mock_storage()
+        storage.delete_episode = AsyncMock(side_effect=Exception("delete failed"))
+        storage.delete_structured = AsyncMock(return_value=True)
+
+        episode = create_test_episode()
+        structured = create_test_structured()
+
+        txn = TransactionContext(storage=storage)
+        await txn.store_episode(episode)
+        await txn.store_structured(structured)
+
+        # Should not raise, and should still try to delete structured
+        rolled_back = await txn.rollback()
+
+        # Only structured was successfully rolled back
+        assert rolled_back == 1
+        storage.delete_structured.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_multiple_operations_tracked_correctly(self) -> None:
+        """Multiple operations should all be tracked."""
+        storage = create_mock_storage()
+        original_episode = create_test_episode()
+        storage.get_episode = AsyncMock(return_value=original_episode)
+
+        episode = create_test_episode()
+        structured = create_test_structured()
+        audit = create_test_audit()
+
+        async with TransactionContext(storage=storage) as txn:
+            await txn.store_episode(episode)
+            await txn.store_structured(structured)
+            await txn.update_episode(episode)
+            await txn.log_audit(audit)
+
+            assert len(txn.operations) == 4
+            assert txn.operations[0].operation == OperationType.STORE_EPISODE
+            assert txn.operations[1].operation == OperationType.STORE_STRUCTURED
+            assert txn.operations[2].operation == OperationType.UPDATE_EPISODE
+            assert txn.operations[3].operation == OperationType.LOG_AUDIT
+
+            txn.commit()
+
+
+class TestTransactionMixin:
+    """Tests for TransactionMixin on EngramStorage."""
+
+    def test_storage_has_transaction_method(self) -> None:
+        """EngramStorage should have transaction() method."""
+        from engram.storage import EngramStorage
+
+        storage = EngramStorage()
+        assert hasattr(storage, "transaction")
+        assert callable(storage.transaction)


### PR DESCRIPTION
## Summary
Fixes #163 - Missing transaction boundaries in encode() operation

Implements a compensating transaction pattern for `encode()` storage operations since Qdrant doesn't support native transactions.

### Changes
- **New `TransactionContext` class** - Tracks storage operations and rolls them back on failure
- **`TransactionMixin` for `EngramStorage`** - Adds `storage.transaction()` method
- **Atomic `encode()` operations** - All storage operations wrapped in transaction context
- **LIFO rollback** - Operations rolled back in reverse order with proper error handling
- **Test utilities** - `MockTransactionContext` and `add_transaction_support()` for tests

### Transaction Behavior

| Operation | Rollback Action |
|-----------|----------------|
| `store_episode` | `delete_episode()` |
| `store_structured` | `delete_structured()` |
| `update_episode` | Restore original data |
| `log_audit` | No rollback (append-only) |

- On **commit()**: Operations cleared (no-op, changes already persisted to Qdrant)
- On **exception**: Operations rolled back in LIFO order, continues even if individual rollbacks fail

### Example
```python
async with self.storage.transaction() as txn:
    await txn.store_episode(episode)
    await txn.store_structured(structured)
    await txn.update_episode(episode)
    await txn.log_audit(audit_entry)
    txn.commit()

# Working memory update happens AFTER transaction commits
self._working_memory.append(episode)
```

## Test plan
- [x] All 939 tests pass
- [x] 15 new transaction-specific tests
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [x] Tests verify rollback order (LIFO)
- [x] Tests verify rollback continues on individual failures