### PR TITLE
fix: add atomic bidirectional linking at storage layer (#162)

### DIFF
--- a/src/engram/storage/__init__.py
+++ b/src/engram/storage/__init__.py
@@ -15,6 +15,7 @@ Example:
 
 from .base import COLLECTION_NAMES, DEFAULT_EMBEDDING_DIM
 from .client import EngramStorage
+from .linking import LinkResult
 from .search import ScoredResult
 from .transaction import TransactionContext
 
@@ -22,6 +23,7 @@ __all__ = [
     "EngramStorage",
     "ScoredResult",
     "TransactionContext",
+    "LinkResult",
     "COLLECTION_NAMES",
     "DEFAULT_EMBEDDING_DIM",
 ]

--- a/src/engram/storage/client.py
+++ b/src/engram/storage/client.py
@@ -24,6 +24,7 @@ from .audit import AuditMixin
 from .base import COLLECTION_NAMES, DEFAULT_EMBEDDING_DIM, StorageBase
 from .crud import CRUDMixin
 from .history import HistoryMixin
+from .linking import LinkingMixin
 from .search import SearchMixin
 from .store import StoreMixin
 from .transaction import TransactionMixin
@@ -66,6 +67,7 @@ class EngramStorage(
     HistoryMixin,
     WebhookMixin,
     TransactionMixin,
+    LinkingMixin,
     StorageBase,
 ):
     """Async Qdrant storage client for Engram memories.
@@ -80,6 +82,8 @@ class EngramStorage(
     - AuditMixin: log_audit, get_audit_log
     - HistoryMixin: log_history, get_memory_history, get_user_history
     - WebhookMixin: store_webhook, list_webhooks, log_delivery, etc.
+    - TransactionMixin: transaction() context manager for atomic operations
+    - LinkingMixin: link_memories, unlink_memories (bidirectional linking)
 
     Attributes:
         client: Async Qdrant client instance.

--- a/src/engram/storage/linking.py
+++ b/src/engram/storage/linking.py
@@ -1,0 +1,371 @@
+"""Bidirectional linking operations for Engram storage.
+
+Provides atomic methods to create and remove bidirectional links between
+SemanticMemory and ProceduralMemory instances. This ensures A-MEM multi-hop
+reasoning works correctly by maintaining consistent graph traversal.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+if TYPE_CHECKING:
+    from engram.models import ProceduralMemory, SemanticMemory
+
+logger = logging.getLogger(__name__)
+
+# Type alias for linkable memory types
+LinkableMemoryType = Literal["semantic", "procedural"]
+
+
+@dataclass
+class LinkResult:
+    """Result of a link operation.
+
+    Attributes:
+        success: Whether both sides were successfully linked.
+        source_updated: Whether the source memory was updated.
+        target_updated: Whether the target memory was updated.
+        source_id: ID of the source memory.
+        target_id: ID of the target memory.
+        link_type: Type of link created.
+        error: Error message if linking failed.
+    """
+
+    success: bool
+    source_updated: bool
+    target_updated: bool
+    source_id: str
+    target_id: str
+    link_type: str
+    error: str | None = None
+
+
+class LinkingMixin:
+    """Mixin providing bidirectional linking operations for EngramStorage.
+
+    This mixin expects the following methods from the base class:
+    - get_semantic(memory_id, user_id) -> SemanticMemory | None
+    - get_procedural(memory_id, user_id) -> ProceduralMemory | None
+    - update_semantic_memory(memory) -> bool
+    - update_procedural_memory(memory) -> bool
+    """
+
+    # These will be provided by the base class
+    get_semantic: Any
+    get_procedural: Any
+    update_semantic_memory: Any
+    update_procedural_memory: Any
+
+    async def link_memories(
+        self,
+        source_id: str,
+        target_id: str,
+        user_id: str,
+        link_type: str = "related",
+        source_type: LinkableMemoryType | None = None,
+        target_type: LinkableMemoryType | None = None,
+        bidirectional: bool = True,
+    ) -> LinkResult:
+        """Create a bidirectional link between two memories.
+
+        This is the recommended way to create links, as it ensures both
+        memories are updated atomically (best-effort since Qdrant doesn't
+        support transactions).
+
+        Args:
+            source_id: ID of the source memory.
+            target_id: ID of the target memory.
+            user_id: User ID for multi-tenancy verification.
+            link_type: Type of link (related, supersedes, contradicts).
+            source_type: Type of source memory (semantic/procedural).
+                        If None, auto-detected from ID prefix.
+            target_type: Type of target memory (semantic/procedural).
+                        If None, auto-detected from ID prefix.
+            bidirectional: If True (default), create reverse link too.
+
+        Returns:
+            LinkResult with success status and details.
+
+        Example:
+            ```python
+            result = await storage.link_memories(
+                source_id="sem_abc123",
+                target_id="sem_def456",
+                user_id="user_1",
+                link_type="related",
+            )
+            if result.success:
+                print("Both memories linked")
+            ```
+        """
+        # Auto-detect types from ID prefixes
+        source_type = source_type or self._detect_memory_type(source_id)
+        target_type = target_type or self._detect_memory_type(target_id)
+
+        if source_type is None:
+            return LinkResult(
+                success=False,
+                source_updated=False,
+                target_updated=False,
+                source_id=source_id,
+                target_id=target_id,
+                link_type=link_type,
+                error=f"Cannot determine memory type for source: {source_id}",
+            )
+
+        if target_type is None:
+            return LinkResult(
+                success=False,
+                source_updated=False,
+                target_updated=False,
+                source_id=source_id,
+                target_id=target_id,
+                link_type=link_type,
+                error=f"Cannot determine memory type for target: {target_id}",
+            )
+
+        # Fetch both memories
+        source = await self._get_linkable_memory(source_id, user_id, source_type)
+        target = await self._get_linkable_memory(target_id, user_id, target_type)
+
+        if source is None:
+            return LinkResult(
+                success=False,
+                source_updated=False,
+                target_updated=False,
+                source_id=source_id,
+                target_id=target_id,
+                link_type=link_type,
+                error=f"Source memory not found: {source_id}",
+            )
+
+        if target is None:
+            return LinkResult(
+                success=False,
+                source_updated=False,
+                target_updated=False,
+                source_id=source_id,
+                target_id=target_id,
+                link_type=link_type,
+                error=f"Target memory not found: {target_id}",
+            )
+
+        # Add forward link (source → target)
+        source.add_link(target_id, link_type)
+        source_updated = await self._update_linkable_memory(source, source_type)
+
+        if not source_updated:
+            return LinkResult(
+                success=False,
+                source_updated=False,
+                target_updated=False,
+                source_id=source_id,
+                target_id=target_id,
+                link_type=link_type,
+                error="Failed to update source memory",
+            )
+
+        # Add reverse link (target → source) if bidirectional
+        target_updated = True
+        if bidirectional:
+            target.add_link(source_id, link_type)
+            target_updated = await self._update_linkable_memory(target, target_type)
+
+            if not target_updated:
+                # Best-effort: source was updated but target failed
+                # Log warning but don't rollback source (partial success)
+                logger.warning(
+                    "Bidirectional link partially failed: source %s updated, "
+                    "target %s failed to update",
+                    source_id,
+                    target_id,
+                )
+                return LinkResult(
+                    success=False,
+                    source_updated=True,
+                    target_updated=False,
+                    source_id=source_id,
+                    target_id=target_id,
+                    link_type=link_type,
+                    error="Failed to update target memory (source was updated)",
+                )
+
+        logger.debug(
+            "Created %slink: %s ↔ %s (type=%s)",
+            "bidirectional " if bidirectional else "",
+            source_id,
+            target_id,
+            link_type,
+        )
+
+        return LinkResult(
+            success=True,
+            source_updated=True,
+            target_updated=target_updated if bidirectional else False,
+            source_id=source_id,
+            target_id=target_id,
+            link_type=link_type,
+        )
+
+    async def unlink_memories(
+        self,
+        source_id: str,
+        target_id: str,
+        user_id: str,
+        source_type: LinkableMemoryType | None = None,
+        target_type: LinkableMemoryType | None = None,
+        bidirectional: bool = True,
+    ) -> LinkResult:
+        """Remove a bidirectional link between two memories.
+
+        Args:
+            source_id: ID of the source memory.
+            target_id: ID of the target memory.
+            user_id: User ID for multi-tenancy verification.
+            source_type: Type of source memory (semantic/procedural).
+                        If None, auto-detected from ID prefix.
+            target_type: Type of target memory (semantic/procedural).
+                        If None, auto-detected from ID prefix.
+            bidirectional: If True (default), remove reverse link too.
+
+        Returns:
+            LinkResult with success status and details.
+        """
+        # Auto-detect types from ID prefixes
+        source_type = source_type or self._detect_memory_type(source_id)
+        target_type = target_type or self._detect_memory_type(target_id)
+
+        if source_type is None:
+            return LinkResult(
+                success=False,
+                source_updated=False,
+                target_updated=False,
+                source_id=source_id,
+                target_id=target_id,
+                link_type="",
+                error=f"Cannot determine memory type for source: {source_id}",
+            )
+
+        if target_type is None:
+            return LinkResult(
+                success=False,
+                source_updated=False,
+                target_updated=False,
+                source_id=source_id,
+                target_id=target_id,
+                link_type="",
+                error=f"Cannot determine memory type for target: {target_id}",
+            )
+
+        # Fetch both memories
+        source = await self._get_linkable_memory(source_id, user_id, source_type)
+        target = await self._get_linkable_memory(target_id, user_id, target_type)
+
+        if source is None:
+            return LinkResult(
+                success=False,
+                source_updated=False,
+                target_updated=False,
+                source_id=source_id,
+                target_id=target_id,
+                link_type="",
+                error=f"Source memory not found: {source_id}",
+            )
+
+        # Remove forward link (source → target)
+        removed = source.remove_link(target_id)
+        source_updated = False
+        if removed:
+            source_updated = await self._update_linkable_memory(source, source_type)
+
+        # Remove reverse link (target → source) if bidirectional
+        target_updated = False
+        if bidirectional and target is not None:
+            removed_reverse = target.remove_link(source_id)
+            if removed_reverse:
+                target_updated = await self._update_linkable_memory(target, target_type)
+
+        success = source_updated or target_updated  # At least one side changed
+
+        logger.debug(
+            "Removed %slink: %s ↔ %s",
+            "bidirectional " if bidirectional else "",
+            source_id,
+            target_id,
+        )
+
+        return LinkResult(
+            success=success,
+            source_updated=source_updated,
+            target_updated=target_updated,
+            source_id=source_id,
+            target_id=target_id,
+            link_type="",
+        )
+
+    def _detect_memory_type(self, memory_id: str) -> LinkableMemoryType | None:
+        """Detect memory type from ID prefix.
+
+        Args:
+            memory_id: Memory ID with type prefix.
+
+        Returns:
+            Memory type or None if unknown.
+        """
+        if memory_id.startswith("sem_"):
+            return "semantic"
+        elif memory_id.startswith("proc_"):
+            return "procedural"
+        return None
+
+    async def _get_linkable_memory(
+        self,
+        memory_id: str,
+        user_id: str,
+        memory_type: LinkableMemoryType,
+    ) -> SemanticMemory | ProceduralMemory | None:
+        """Get a linkable memory by type.
+
+        Args:
+            memory_id: Memory ID.
+            user_id: User ID for multi-tenancy.
+            memory_type: Type of memory to fetch.
+
+        Returns:
+            Memory instance or None if not found.
+        """
+        if memory_type == "semantic":
+            result = await self.get_semantic(memory_id, user_id)
+            return cast("SemanticMemory | None", result)
+        elif memory_type == "procedural":
+            result = await self.get_procedural(memory_id, user_id)
+            return cast("ProceduralMemory | None", result)
+        return None
+
+    async def _update_linkable_memory(
+        self,
+        memory: SemanticMemory | ProceduralMemory,
+        memory_type: LinkableMemoryType,
+    ) -> bool:
+        """Update a linkable memory by type.
+
+        Args:
+            memory: Memory instance to update.
+            memory_type: Type of memory.
+
+        Returns:
+            True if updated successfully.
+        """
+        if memory_type == "semantic":
+            result = await self.update_semantic_memory(memory)
+            return cast(bool, result)
+        elif memory_type == "procedural":
+            result = await self.update_procedural_memory(memory)
+            return cast(bool, result)
+        return False
+
+
+__all__ = ["LinkingMixin", "LinkResult", "LinkableMemoryType"]

--- a/tests/test_storage_linking.py
+++ b/tests/test_storage_linking.py
@@ -1,0 +1,352 @@
+"""Tests for storage linking operations.
+
+Tests the LinkingMixin which provides atomic bidirectional linking at the
+storage layer to ensure consistency between related memories.
+"""
+
+from __future__ import annotations
+
+from types import MethodType
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from engram.models import ConfidenceScore, SemanticMemory
+from engram.storage.linking import LinkingMixin, LinkResult
+
+
+def create_test_semantic(memory_id: str = "sem_test") -> SemanticMemory:
+    """Create a test semantic memory."""
+    return SemanticMemory(
+        id=memory_id,
+        content="Test semantic memory",
+        source_episode_ids=["ep_1"],
+        user_id="user_1",
+        confidence=ConfidenceScore.for_inferred(),
+        embedding=[0.1] * 1536,
+    )
+
+
+def create_mock_storage() -> MagicMock:
+    """Create a mock storage with all mixin methods properly bound."""
+    storage = MagicMock()
+
+    # Set up base async methods
+    storage.get_semantic = AsyncMock(return_value=None)
+    storage.get_procedural = AsyncMock(return_value=None)
+    storage.update_semantic_memory = AsyncMock(return_value=True)
+    storage.update_procedural_memory = AsyncMock(return_value=True)
+
+    # Bind all LinkingMixin methods to the mock as proper bound methods
+    storage._detect_memory_type = MethodType(LinkingMixin._detect_memory_type, storage)
+    storage._get_linkable_memory = MethodType(LinkingMixin._get_linkable_memory, storage)
+    storage._update_linkable_memory = MethodType(LinkingMixin._update_linkable_memory, storage)
+    storage.link_memories = MethodType(LinkingMixin.link_memories, storage)
+    storage.unlink_memories = MethodType(LinkingMixin.unlink_memories, storage)
+
+    return storage
+
+
+class TestDetectMemoryType:
+    """Tests for memory type detection from ID prefix."""
+
+    def test_detects_semantic_from_prefix(self) -> None:
+        """Should detect semantic type from sem_ prefix."""
+        mixin = LinkingMixin()
+        assert mixin._detect_memory_type("sem_abc123") == "semantic"
+
+    def test_detects_procedural_from_prefix(self) -> None:
+        """Should detect procedural type from proc_ prefix."""
+        mixin = LinkingMixin()
+        assert mixin._detect_memory_type("proc_abc123") == "procedural"
+
+    def test_returns_none_for_unknown_prefix(self) -> None:
+        """Should return None for unknown prefix."""
+        mixin = LinkingMixin()
+        assert mixin._detect_memory_type("ep_abc123") is None
+        assert mixin._detect_memory_type("struct_abc123") is None
+        assert mixin._detect_memory_type("unknown") is None
+
+
+class TestLinkMemories:
+    """Tests for bidirectional link creation."""
+
+    @pytest.fixture
+    def mock_storage(self) -> MagicMock:
+        """Create a properly configured mock storage."""
+        return create_mock_storage()
+
+    @pytest.mark.asyncio
+    async def test_link_semantic_to_semantic(self, mock_storage: MagicMock) -> None:
+        """Should create bidirectional link between two semantic memories."""
+        source = create_test_semantic("sem_source")
+        target = create_test_semantic("sem_target")
+
+        mock_storage.get_semantic = AsyncMock(
+            side_effect=lambda id, _: source if id == "sem_source" else target
+        )
+        mock_storage.update_semantic_memory = AsyncMock(return_value=True)
+
+        result = await mock_storage.link_memories(
+            source_id="sem_source",
+            target_id="sem_target",
+            user_id="user_1",
+            link_type="related",
+        )
+
+        assert result.success is True
+        assert result.source_updated is True
+        assert result.target_updated is True
+        assert "sem_target" in source.related_ids
+        assert "sem_source" in target.related_ids
+
+    @pytest.mark.asyncio
+    async def test_link_with_unidirectional(self, mock_storage: MagicMock) -> None:
+        """Should create only forward link when bidirectional=False."""
+        source = create_test_semantic("sem_source")
+        target = create_test_semantic("sem_target")
+
+        mock_storage.get_semantic = AsyncMock(
+            side_effect=lambda id, _: source if id == "sem_source" else target
+        )
+        mock_storage.update_semantic_memory = AsyncMock(return_value=True)
+
+        result = await mock_storage.link_memories(
+            source_id="sem_source",
+            target_id="sem_target",
+            user_id="user_1",
+            link_type="related",
+            bidirectional=False,
+        )
+
+        assert result.success is True
+        assert result.source_updated is True
+        assert result.target_updated is False
+        assert "sem_target" in source.related_ids
+        assert "sem_source" not in target.related_ids
+
+    @pytest.mark.asyncio
+    async def test_link_preserves_link_type(self, mock_storage: MagicMock) -> None:
+        """Should preserve the specified link type."""
+        source = create_test_semantic("sem_source")
+        target = create_test_semantic("sem_target")
+
+        mock_storage.get_semantic = AsyncMock(
+            side_effect=lambda id, _: source if id == "sem_source" else target
+        )
+        mock_storage.update_semantic_memory = AsyncMock(return_value=True)
+
+        await mock_storage.link_memories(
+            source_id="sem_source",
+            target_id="sem_target",
+            user_id="user_1",
+            link_type="supersedes",
+        )
+
+        assert source.link_types["sem_target"] == "supersedes"
+        assert target.link_types["sem_source"] == "supersedes"
+
+    @pytest.mark.asyncio
+    async def test_link_fails_for_missing_source(self, mock_storage: MagicMock) -> None:
+        """Should fail gracefully when source memory not found."""
+        mock_storage.get_semantic = AsyncMock(return_value=None)
+
+        result = await mock_storage.link_memories(
+            source_id="sem_missing",
+            target_id="sem_target",
+            user_id="user_1",
+        )
+
+        assert result.success is False
+        assert result.source_updated is False
+        assert "Source memory not found" in str(result.error)
+
+    @pytest.mark.asyncio
+    async def test_link_fails_for_missing_target(self, mock_storage: MagicMock) -> None:
+        """Should fail gracefully when target memory not found."""
+        source = create_test_semantic("sem_source")
+
+        mock_storage.get_semantic = AsyncMock(
+            side_effect=lambda id, _: source if id == "sem_source" else None
+        )
+
+        result = await mock_storage.link_memories(
+            source_id="sem_source",
+            target_id="sem_missing",
+            user_id="user_1",
+        )
+
+        assert result.success is False
+        assert result.source_updated is False
+        assert "Target memory not found" in str(result.error)
+
+    @pytest.mark.asyncio
+    async def test_link_fails_for_unknown_source_type(self, mock_storage: MagicMock) -> None:
+        """Should fail gracefully when source type cannot be determined."""
+        result = await mock_storage.link_memories(
+            source_id="unknown_prefix",
+            target_id="sem_target",
+            user_id="user_1",
+        )
+
+        assert result.success is False
+        assert "Cannot determine memory type for source" in str(result.error)
+
+    @pytest.mark.asyncio
+    async def test_link_partial_failure_reported(self, mock_storage: MagicMock) -> None:
+        """Should report partial failure when target update fails."""
+        source = create_test_semantic("sem_source")
+        target = create_test_semantic("sem_target")
+
+        mock_storage.get_semantic = AsyncMock(
+            side_effect=lambda id, _: source if id == "sem_source" else target
+        )
+        # Source update succeeds, target update fails
+        mock_storage.update_semantic_memory = AsyncMock(
+            side_effect=lambda mem: mem.id == "sem_source"
+        )
+
+        result = await mock_storage.link_memories(
+            source_id="sem_source",
+            target_id="sem_target",
+            user_id="user_1",
+        )
+
+        assert result.success is False
+        assert result.source_updated is True
+        assert result.target_updated is False
+        assert "source was updated" in str(result.error)
+
+
+class TestUnlinkMemories:
+    """Tests for bidirectional link removal."""
+
+    @pytest.fixture
+    def mock_storage(self) -> MagicMock:
+        """Create a properly configured mock storage."""
+        return create_mock_storage()
+
+    @pytest.mark.asyncio
+    async def test_unlink_removes_both_directions(self, mock_storage: MagicMock) -> None:
+        """Should remove links in both directions."""
+        source = create_test_semantic("sem_source")
+        target = create_test_semantic("sem_target")
+        # Pre-link them
+        source.add_link("sem_target", "related")
+        target.add_link("sem_source", "related")
+
+        mock_storage.get_semantic = AsyncMock(
+            side_effect=lambda id, _: source if id == "sem_source" else target
+        )
+        mock_storage.update_semantic_memory = AsyncMock(return_value=True)
+
+        result = await mock_storage.unlink_memories(
+            source_id="sem_source",
+            target_id="sem_target",
+            user_id="user_1",
+        )
+
+        assert result.success is True
+        assert result.source_updated is True
+        assert result.target_updated is True
+        assert "sem_target" not in source.related_ids
+        assert "sem_source" not in target.related_ids
+
+    @pytest.mark.asyncio
+    async def test_unlink_with_unidirectional(self, mock_storage: MagicMock) -> None:
+        """Should only remove forward link when bidirectional=False."""
+        source = create_test_semantic("sem_source")
+        target = create_test_semantic("sem_target")
+        source.add_link("sem_target", "related")
+        target.add_link("sem_source", "related")
+
+        mock_storage.get_semantic = AsyncMock(
+            side_effect=lambda id, _: source if id == "sem_source" else target
+        )
+        mock_storage.update_semantic_memory = AsyncMock(return_value=True)
+
+        result = await mock_storage.unlink_memories(
+            source_id="sem_source",
+            target_id="sem_target",
+            user_id="user_1",
+            bidirectional=False,
+        )
+
+        assert result.success is True
+        assert result.source_updated is True
+        assert result.target_updated is False
+        assert "sem_target" not in source.related_ids
+        assert "sem_source" in target.related_ids  # Should still exist
+
+    @pytest.mark.asyncio
+    async def test_unlink_nonexistent_link_reports_no_update(self, mock_storage: MagicMock) -> None:
+        """Should report no updates when links don't exist."""
+        source = create_test_semantic("sem_source")
+        target = create_test_semantic("sem_target")
+        # No pre-existing links
+
+        mock_storage.get_semantic = AsyncMock(
+            side_effect=lambda id, _: source if id == "sem_source" else target
+        )
+        mock_storage.update_semantic_memory = AsyncMock(return_value=True)
+
+        result = await mock_storage.unlink_memories(
+            source_id="sem_source",
+            target_id="sem_target",
+            user_id="user_1",
+        )
+
+        # No links existed, so nothing was updated
+        assert result.source_updated is False
+        assert result.target_updated is False
+
+
+class TestLinkResult:
+    """Tests for LinkResult dataclass."""
+
+    def test_link_result_success(self) -> None:
+        """Should create successful LinkResult."""
+        result = LinkResult(
+            success=True,
+            source_updated=True,
+            target_updated=True,
+            source_id="sem_1",
+            target_id="sem_2",
+            link_type="related",
+        )
+        assert result.success is True
+        assert result.error is None
+
+    def test_link_result_failure(self) -> None:
+        """Should create failed LinkResult with error."""
+        result = LinkResult(
+            success=False,
+            source_updated=False,
+            target_updated=False,
+            source_id="sem_1",
+            target_id="sem_2",
+            link_type="related",
+            error="Memory not found",
+        )
+        assert result.success is False
+        assert result.error == "Memory not found"
+
+
+class TestStorageHasLinkMethods:
+    """Tests that EngramStorage has link methods."""
+
+    def test_storage_has_link_memories(self) -> None:
+        """EngramStorage should have link_memories method."""
+        from engram.storage import EngramStorage
+
+        storage = EngramStorage()
+        assert hasattr(storage, "link_memories")
+        assert callable(storage.link_memories)
+
+    def test_storage_has_unlink_memories(self) -> None:
+        """EngramStorage should have unlink_memories method."""
+        from engram.storage import EngramStorage
+
+        storage = EngramStorage()
+        assert hasattr(storage, "unlink_memories")
+        assert callable(storage.unlink_memories)


### PR DESCRIPTION
## Summary

Fixes #162 - Bidirectional link inconsistency in SemanticMemory and ProceduralMemory.

The existing `add_link()` and `remove_link()` methods on memory models only update one side of the relationship, leading to inconsistent graph state where `memory_a.related_ids` contains `memory_b.id` but `memory_b.related_ids` does not contain `memory_a.id`.

This PR adds a `LinkingMixin` to the storage layer that provides atomic bidirectional linking operations:

### Changes

- **`src/engram/storage/linking.py`** (new): 
  - `LinkResult` dataclass for detailed operation results
  - `LinkingMixin` class with:
    - `link_memories()` - Creates bidirectional links atomically
    - `unlink_memories()` - Removes bidirectional links atomically
    - `_detect_memory_type()` - Auto-detects type from ID prefix (sem_, proc_)
    - `_get_linkable_memory()` / `_update_linkable_memory()` - Type-dispatched helpers

- **`src/engram/storage/client.py`**: Added `LinkingMixin` to `EngramStorage` inheritance chain

- **`src/engram/storage/__init__.py`**: Export `LinkResult`

- **`tests/test_storage_linking.py`** (new): 17 tests covering:
  - Memory type detection from ID prefix
  - Bidirectional and unidirectional linking
  - Link type preservation
  - Error handling (missing memories, unknown types)
  - Partial failure reporting
  - Bidirectional and unidirectional unlinking

### Usage

```python
# Create bidirectional link
result = await storage.link_memories(
    source_id="sem_abc123",
    target_id="sem_def456",
    user_id="user_1",
    link_type="related",
)
if result.success:
    print("Both memories now reference each other")

# Remove bidirectional link  
result = await storage.unlink_memories(
    source_id="sem_abc123",
    target_id="sem_def456",
    user_id="user_1",
)
```

### Design Decisions

- **Storage layer**: Linking at the storage layer ensures both memories are always updated together
- **Auto-detection**: Memory type is inferred from ID prefix to simplify API
- **Best-effort atomicity**: Since Qdrant lacks transactions, partial failures are reported with detailed status
- **Backward compatibility**: Existing `add_link()` / `remove_link()` on models remain for direct use cases

## Test plan

- [x] All 941 tests pass
- [x] 17 new tests for linking operations
- [x] mypy strict mode passes
- [x] ruff check and format pass
- [x] Pre-commit hooks pass