### PR TITLE
docs: document Docker env var gotcha for MCP setup

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -401,19 +401,18 @@ class TestWorkingMemorySettings:
 class TestSyncOpenAIApiKey:
     """Tests for ENGRAM_OPENAI_API_KEY -> OPENAI_API_KEY sync."""
 
-    def test_sync_sets_openai_api_key_when_not_present(self):
-        """sync_openai_api_key should set OPENAI_API_KEY from settings."""
-        # Ensure OPENAI_API_KEY is not set
+    def test_auto_sync_sets_openai_api_key_at_init(self):
+        """OPENAI_API_KEY should be auto-synced at Settings initialization."""
+        # Ensure OPENAI_API_KEY is not set before we start
         env = {"ENGRAM_OPENAI_API_KEY": "test-key-123"}
         with patch.dict(os.environ, env, clear=False):
             # Remove OPENAI_API_KEY if present
             os.environ.pop("OPENAI_API_KEY", None)
 
-            settings = Settings(openai_api_key="test-key-123", _env_file=None)
-            assert os.environ.get("OPENAI_API_KEY") is None
+            # Creating Settings should auto-sync the key
+            Settings(openai_api_key="test-key-123", _env_file=None)
 
-            settings.sync_openai_api_key()
-
+            # Key should now be set automatically (no need to call sync_openai_api_key)
             assert os.environ.get("OPENAI_API_KEY") == "test-key-123"
 
             # Clean up


### PR DESCRIPTION
## Summary

Addresses the issue where `engram` MCP server fails with "The api_key client option must be set" error when running from repos other than the engram repo itself.

**Root cause:** Docker's `-e VAR_NAME` syntax (without `=value`) tells Docker to inherit from the host environment, but this doesn't work when Claude Code launches the MCP server because the `env` block in MCP config doesn't propagate to Docker's inheritance mechanism.

## Changes

- **README.md + docs/mcp.md**: Document the Docker `-e VAR` gotcha with correct examples showing `-e VAR=value` form
- **src/engram/config.py**: Auto-sync `ENGRAM_OPENAI_API_KEY` → `OPENAI_API_KEY` at Settings initialization (no manual `sync_openai_api_key()` call needed)
- **tests/test_config.py**: Update test to reflect auto-sync behavior
- **Troubleshooting section**: Explains the exact error message and fix

## Test plan

- [x] `pytest tests/test_config.py -k sync` passes
- [x] Pre-commit hooks pass (ruff, mypy, formatting)