### PR TITLE
feat: add postgres CDC support with wal2json

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -30,13 +30,20 @@ services:
   # PostgreSQL - For DBOS durable execution (always started)
   # ==========================================================================
   postgres:
-    image: postgres:15-alpine
+    build:
+      context: ./docker/postgres
+      dockerfile: Dockerfile
     ports:
       - "5432:5432"
     environment:
       POSTGRES_USER: engram
       POSTGRES_PASSWORD: engram
       POSTGRES_DB: engram_dbos
+    command: >
+      postgres
+      -c wal_level=logical
+      -c max_replication_slots=4
+      -c max_wal_senders=4
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,0 +1,7 @@
+# PostgreSQL with CDC support (wal2json)
+FROM postgres:15
+
+# Install wal2json for CDC logical decoding
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-15-wal2json \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Add `docker/postgres/Dockerfile` with wal2json extension for CDC
- Configure WAL for logical replication in `docker-compose.full.yml`
- Enables change data capture for future event sourcing features

## Changes
- `docker/postgres/Dockerfile`: Custom postgres:15 image with `postgresql-15-wal2json`
- `docker-compose.full.yml`: Build from local Dockerfile, add WAL config (`wal_level=logical`, replication slots)

## Test plan
- [x] `docker compose -f docker-compose.full.yml build postgres` succeeds
- [x] Pre-commit hooks pass