### PR TITLE
feat: require org_id for consolidation, promotion, and decay workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ async with EngramService.create() as engram:
     verified = await engram.verify(memories[0].memory_id, user_id="user_123")
     print(verified.explanation)
 
-    # Run consolidation (N episodes → semantic memory)
-    await engram.consolidate(user_id="user_123")
+    # Run consolidation (N episodes → semantic memory, scoped to project)
+    await engram.consolidate(user_id="user_123", org_id="my-project")
 ```
 
 ### REST API

--- a/docs/api.md
+++ b/docs/api.md
@@ -618,7 +618,7 @@ Trigger memory consolidation workflow. Consolidates episodic memories into seman
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `user_id` | string | Yes | - | User ID for isolation |
-| `org_id` | string | No | `null` | Optional org filter |
+| `org_id` | string | Yes | - | Organization/project ID (prevents cross-project bleed) |
 | `consolidation_passes` | int | No | `1` | Number of LLM passes for refinement (1-5) |
 | `similarity_threshold` | float | No | `0.7` | Threshold for memory linking (0.0-1.0) |
 | `async_execution` | bool | No | `false` | Run in background, return workflow ID |
@@ -660,7 +660,7 @@ Trigger memory decay workflow. Applies time-based confidence decay.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `user_id` | string | Yes | - | User ID for isolation |
-| `org_id` | string | No | `null` | Optional org filter |
+| `org_id` | string | Yes | - | Organization/project ID (prevents cross-project bleed) |
 | `run_promotion` | bool | No | `true` | Run promotion workflow after decay |
 | `async_execution` | bool | No | `false` | Run in background |
 
@@ -700,7 +700,7 @@ Trigger promotion/synthesis workflow. Promotes semantic memories to procedural.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `user_id` | string | Yes | - | User ID for isolation |
-| `org_id` | string | No | `null` | Optional org filter |
+| `org_id` | string | Yes | - | Organization/project ID (prevents cross-project bleed) |
 | `async_execution` | bool | No | `false` | Run in background |
 
 **Response (200 OK):**
@@ -782,7 +782,7 @@ Trigger batch structure workflow for multiple episodes.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `user_id` | string | Yes | - | User ID for isolation |
-| `org_id` | string | No | `null` | Optional org filter |
+| `org_id` | string | Yes | - | Organization/project ID (prevents cross-project bleed) |
 | `limit` | int | No | `null` | Max episodes to process (null = all unstructured) |
 | `model` | string | No | default | Optional model override |
 | `async_execution` | bool | No | `false` | Run in background |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -576,7 +576,7 @@ async with EngramService.create() as engram:
     )
 
     # Background operations (run as durable workflows)
-    await engram.consolidate(user_id="user_123")  # Extract, link, strengthen
+    await engram.consolidate(user_id="user_123", org_id="my-project")  # Extract, link, strengthen
 ```
 
 ## Background Operations

--- a/src/engram/api/schemas.py
+++ b/src/engram/api/schemas.py
@@ -705,14 +705,17 @@ class WorkflowTriggerRequest(BaseModel):
 
     Attributes:
         user_id: User ID for multi-tenancy isolation.
-        org_id: Optional organization ID filter.
+        org_id: Organization/project ID for isolation.
         async_execution: If True, run in background and return workflow ID for polling.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     user_id: str = Field(min_length=1, description="User ID for isolation")
-    org_id: str | None = Field(default=None, description="Optional org ID filter")
+    org_id: str = Field(
+        min_length=1,
+        description="Organization/project ID. Required to scope workflows to a single project.",
+    )
     async_execution: bool = Field(
         default=False,
         description="If True, run in background and return workflow ID for status polling",

--- a/src/engram/mcp/server.py
+++ b/src/engram/mcp/server.py
@@ -628,6 +628,9 @@ def create_server() -> FastMCP:
         episodes for a user and creates a semantic memory that captures the
         key facts and relationships. This is the core learning loop.
 
+        Consolidation is scoped to the current project/org to prevent
+        cross-project memory bleed.
+
         Based on Complementary Learning Systems theory: episodic (hippocampus)
         to semantic (neocortex) transfer with compression.
 
@@ -649,8 +652,17 @@ def create_server() -> FastMCP:
                 indent=2,
             )
 
-        # Auto-detect org_id from project context
+        # Auto-detect org_id from project context (required for consolidation)
         org_id = get_project_context()
+        if not org_id:
+            return json.dumps(
+                {
+                    "error": "org_id required for consolidation. "
+                    "Set ENGRAM_ORG env var or run from within a git repository.",
+                    "success": False,
+                },
+                indent=2,
+            )
 
         service = await get_service()
 
@@ -682,7 +694,10 @@ def create_server() -> FastMCP:
         Creates or updates a procedural memory that captures behavioral patterns,
         preferences, and communication style from all semantic memories.
 
-        Design: ONE procedural memory per user (replaces existing).
+        Promotion is scoped to the current project/org to prevent
+        cross-project memory bleed.
+
+        Design: ONE procedural memory per (user, org) pair (replaces existing).
 
         AUTO-DETECTION:
         - user_id: Auto-detected from ENGRAM_USER env, git user.name, or system username
@@ -702,8 +717,17 @@ def create_server() -> FastMCP:
                 indent=2,
             )
 
-        # Auto-detect org_id from project context
+        # Auto-detect org_id from project context (required for promotion)
         org_id = get_project_context()
+        if not org_id:
+            return json.dumps(
+                {
+                    "error": "org_id required for promotion. "
+                    "Set ENGRAM_ORG env var or run from within a git repository.",
+                    "success": False,
+                },
+                indent=2,
+            )
 
         service = await get_service()
 

--- a/src/engram/service/encode.py
+++ b/src/engram/service/encode.py
@@ -448,11 +448,18 @@ class EncodeMixin:
         """Trigger consolidation for high-importance episodes.
 
         Uses the configured workflow backend for execution.
+        Skips if org_id is not available, since consolidation must be
+        scoped to a project to prevent cross-project bleed.
 
         Args:
             user_id: User ID for multi-tenancy.
-            org_id: Optional organization ID.
+            org_id: Organization/project ID. Consolidation is skipped if None.
         """
+        if org_id is None:
+            logger.debug(
+                "Skipping high-importance consolidation: org_id required for project-scoped consolidation"
+            )
+            return
         assert self.workflow_backend is not None, "workflow_backend not initialized"
         try:
             result = await self.workflow_backend.run_consolidation(

--- a/src/engram/workflows/backend.py
+++ b/src/engram/workflows/backend.py
@@ -15,11 +15,12 @@ Example:
     settings = Settings(durable_backend="dbos")
     backend = get_workflow_backend(settings)
 
-    # Run consolidation
+    # Run consolidation (org_id required to scope to a project)
     result = await backend.run_consolidation(
         storage=storage,
         embedder=embedder,
         user_id="user123",
+        org_id="my-project",
     )
     ```
 """
@@ -97,19 +98,20 @@ class WorkflowBackend(Protocol):
         storage: EngramStorage,
         embedder: Embedder,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
         consolidation_passes: int = 1,
         similarity_threshold: float = 0.7,
     ) -> ConsolidationResult:
         """Run the consolidation workflow.
 
         Consolidates unsummarized episodes into semantic memories.
+        Scoped to a single org/project to prevent cross-project bleed.
 
         Args:
             storage: EngramStorage instance.
             embedder: Embedder for vector operations.
             user_id: User ID for multi-tenancy.
-            org_id: Optional organization ID.
+            org_id: Organization/project ID for isolation.
             consolidation_passes: Number of passes for consolidation.
             similarity_threshold: Threshold for linking similar memories.
 
@@ -124,19 +126,20 @@ class WorkflowBackend(Protocol):
         storage: EngramStorage,
         settings: Settings,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
         embedder: Embedder | None = None,
         run_promotion: bool = True,
     ) -> DecayResult:
         """Run the decay workflow.
 
         Applies time-based decay to memory confidence scores.
+        Scoped to a single org/project to prevent cross-project bleed.
 
         Args:
             storage: EngramStorage instance.
             settings: Engram settings with decay configuration.
             user_id: User ID for multi-tenancy.
-            org_id: Optional organization ID.
+            org_id: Organization/project ID for isolation.
             embedder: Optional embedder for promotion.
             run_promotion: Whether to run promotion after decay.
 
@@ -201,17 +204,18 @@ class WorkflowBackend(Protocol):
         storage: EngramStorage,
         embedder: Embedder,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
     ) -> SynthesisResult:
         """Run the promotion workflow.
 
         Synthesizes semantic memories into a procedural memory.
+        Scoped to a single org/project to prevent cross-project bleed.
 
         Args:
             storage: EngramStorage instance.
             embedder: Embedder for vector operations.
             user_id: User ID for multi-tenancy.
-            org_id: Optional organization ID.
+            org_id: Organization/project ID for isolation.
 
         Returns:
             SynthesisResult with processing statistics.
@@ -258,7 +262,7 @@ class InProcessBackend:
         storage: EngramStorage,
         embedder: Embedder,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
         consolidation_passes: int = 1,
         similarity_threshold: float = 0.7,
     ) -> ConsolidationResult:
@@ -279,7 +283,7 @@ class InProcessBackend:
         storage: EngramStorage,
         settings: Settings,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
         embedder: Embedder | None = None,
         run_promotion: bool = True,
     ) -> DecayResult:
@@ -340,7 +344,7 @@ class InProcessBackend:
         storage: EngramStorage,
         embedder: Embedder,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
     ) -> SynthesisResult:
         """Run promotion as a direct async call."""
         from .promotion import run_synthesis
@@ -401,7 +405,7 @@ class DBOSBackend:
         storage: EngramStorage,
         embedder: Embedder,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
         consolidation_passes: int = 1,
         similarity_threshold: float = 0.7,
     ) -> ConsolidationResult:
@@ -430,7 +434,7 @@ class DBOSBackend:
         storage: EngramStorage,
         settings: Settings,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
         embedder: Embedder | None = None,
         run_promotion: bool = True,
     ) -> DecayResult:
@@ -515,7 +519,7 @@ class DBOSBackend:
         storage: EngramStorage,
         embedder: Embedder,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
     ) -> SynthesisResult:
         """Run promotion with DBOS durability."""
         self._ensure_initialized()
@@ -599,7 +603,7 @@ class PrefectBackend:
         storage: EngramStorage,
         embedder: Embedder,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
         consolidation_passes: int = 1,
         similarity_threshold: float = 0.7,
     ) -> ConsolidationResult:
@@ -626,7 +630,7 @@ class PrefectBackend:
         storage: EngramStorage,
         settings: Settings,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
         embedder: Embedder | None = None,
         run_promotion: bool = True,
     ) -> DecayResult:
@@ -705,7 +709,7 @@ class PrefectBackend:
         storage: EngramStorage,
         embedder: Embedder,
         user_id: str,
-        org_id: str | None = None,
+        org_id: str,
     ) -> SynthesisResult:
         """Run promotion as a Prefect flow."""
         from prefect import flow

--- a/src/engram/workflows/decay.py
+++ b/src/engram/workflows/decay.py
@@ -53,25 +53,27 @@ async def run_decay(
     storage: EngramStorage,
     settings: Settings,
     user_id: str,
-    org_id: str | None = None,
+    org_id: str,
     embedder: Embedder | None = None,
     run_promotion: bool = True,
 ) -> DecayResult:
     """Run the decay workflow.
 
     This workflow:
-    1. Fetches all semantic memories for the user
+    1. Fetches all semantic memories for the user within the org
     2. Recomputes confidence using time-based decay
     3. Archives memories below archive threshold (confidence-based)
     4. Archives memories with low access count (access-based)
     5. Deletes memories below delete threshold
     6. Runs promotion to elevate behavioral patterns to procedural memory
 
+    Scoped to a single org/project to prevent cross-project bleed.
+
     Args:
         storage: EngramStorage instance.
         settings: Engram settings with decay configuration.
         user_id: User ID for multi-tenancy.
-        org_id: Optional organization ID.
+        org_id: Organization/project ID for isolation.
         embedder: Optional embedder for promotion workflow. Required if run_promotion=True.
         run_promotion: Whether to run promotion after decay. Defaults to True.
 

--- a/src/engram/workflows/promotion.py
+++ b/src/engram/workflows/promotion.py
@@ -139,24 +139,25 @@ async def run_synthesis(
     storage: EngramStorage,
     embedder: Embedder,
     user_id: str,
-    org_id: str | None = None,
+    org_id: str,
 ) -> SynthesisResult:
     """Run procedural synthesis workflow.
 
-    Synthesizes ALL semantic memories into ONE procedural memory.
-    If a procedural memory already exists for the user, it is replaced.
+    Synthesizes ALL semantic memories into ONE procedural memory per
+    (user, org) pair. If a procedural memory already exists, it is replaced.
+    Scoped to a single org/project to prevent cross-project bleed.
 
     This workflow:
-    1. Fetches ALL semantic memories for the user
+    1. Fetches ALL semantic memories for the user within the org
     2. Uses LLM to synthesize behavioral patterns
-    3. Creates/replaces ONE procedural memory
+    3. Creates/replaces ONE procedural memory for this org
     4. Links procedural to all source semantic IDs
 
     Args:
         storage: EngramStorage instance.
         embedder: Embedder for generating vectors.
         user_id: User ID for multi-tenancy.
-        org_id: Optional organization ID.
+        org_id: Organization/project ID for isolation.
 
     Returns:
         SynthesisResult with processing statistics.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1117,6 +1117,7 @@ class TestWorkflowEndpoints:
             "/api/v1/workflows/consolidate",
             json={
                 "user_id": "user_123",
+                "org_id": "test_org",
                 "consolidation_passes": 2,
                 "similarity_threshold": 0.8,
             },
@@ -1174,6 +1175,7 @@ class TestWorkflowEndpoints:
             "/api/v1/workflows/decay",
             json={
                 "user_id": "user_123",
+                "org_id": "test_org",
                 "run_promotion": True,
             },
         )
@@ -1203,6 +1205,7 @@ class TestWorkflowEndpoints:
             "/api/v1/workflows/decay",
             json={
                 "user_id": "user_123",
+                "org_id": "test_org",
                 "run_promotion": False,
             },
         )
@@ -1226,7 +1229,7 @@ class TestWorkflowEndpoints:
 
         response = client.post(
             "/api/v1/workflows/promote",
-            json={"user_id": "user_123"},
+            json={"user_id": "user_123", "org_id": "test_org"},
         )
 
         assert response.status_code == 200
@@ -1352,6 +1355,7 @@ class TestWorkflowEndpoints:
             "/api/v1/workflows/structure/batch",
             json={
                 "user_id": "user_123",
+                "org_id": "test_org",
                 "limit": 10,
             },
         )
@@ -1405,7 +1409,7 @@ class TestWorkflowEndpoints:
 
         response = test_client.post(
             "/api/v1/workflows/consolidate",
-            json={"user_id": "user_123"},
+            json={"user_id": "user_123", "org_id": "test_org"},
         )
 
         assert response.status_code == 503

--- a/tests/test_consolidation.py
+++ b/tests/test_consolidation.py
@@ -281,6 +281,7 @@ class TestRunConsolidation:
             storage=mock_storage,
             embedder=mock_embedder,
             user_id="test_user",
+            org_id="test_org",
         )
 
         assert result.episodes_processed == 0
@@ -325,6 +326,7 @@ class TestRunConsolidation:
                 storage=mock_storage,
                 embedder=mock_embedder,
                 user_id="test_user",
+                org_id="test_org",
             )
 
         # Should process all episodes into ONE semantic memory
@@ -378,6 +380,7 @@ class TestRunConsolidation:
                 storage=mock_storage,
                 embedder=mock_embedder,
                 user_id="test_user",
+                org_id="test_org",
             )
 
             # Verify only user episode was passed to summarization
@@ -635,6 +638,7 @@ class TestConsolidationLinking:
                 storage=mock_storage,
                 embedder=mock_embedder,
                 user_id="test_user",
+                org_id="test_org",
             )
 
         # Should have created memory and link
@@ -678,6 +682,7 @@ class TestConsolidationLinking:
                 storage=mock_storage,
                 embedder=mock_embedder,
                 user_id="test_user",
+                org_id="test_org",
             )
 
         # Memory created but no links
@@ -734,6 +739,7 @@ class TestConsolidationStrengthening:
                 storage=mock_storage,
                 embedder=mock_embedder,
                 user_id="test_user",
+                org_id="test_org",
             )
 
         # Should have created memory and strengthened existing

--- a/tests/test_decay.py
+++ b/tests/test_decay.py
@@ -132,6 +132,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
         )
 
         assert result.memories_updated == 0
@@ -152,6 +153,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
         )
 
         # High confidence memory may be updated if confidence changed
@@ -173,6 +175,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
         )
 
         assert result.memories_archived == 1
@@ -199,6 +202,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
         )
 
         assert result.memories_deleted == 1
@@ -221,6 +225,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
         )
 
         # Already archived, so just updated not newly archived
@@ -250,6 +255,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
         )
 
         # Should have: 1 archived, 1 deleted
@@ -293,6 +299,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
             run_promotion=False,  # Skip promotion for this test
         )
 
@@ -318,6 +325,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
             run_promotion=False,
         )
 
@@ -337,6 +345,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
             embedder=mock_embedder,
             run_promotion=True,
         )
@@ -354,6 +363,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
             embedder=None,
             run_promotion=True,
         )
@@ -373,6 +383,7 @@ class TestRunDecay:
             storage=mock_storage,
             settings=settings,
             user_id="test_user",
+            org_id="test_org",
             embedder=mock_embedder,
             run_promotion=False,  # Explicitly disabled
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -546,6 +546,7 @@ class TestConsolidationIntegration:
             storage=mock_storage,
             embedder=real_embedder,
             user_id="test_user",
+            org_id="test_org",
         )
 
         # Should process all 3 episodes into ONE summary
@@ -575,6 +576,7 @@ class TestConsolidationIntegration:
             storage=mock_storage,
             embedder=real_embedder,
             user_id="test_user",
+            org_id="test_org",
         )
 
         # Get the summary content
@@ -601,6 +603,7 @@ class TestConsolidationIntegration:
             storage=empty_storage,
             embedder=real_embedder,
             user_id="test_user",
+            org_id="test_org",
         )
 
         assert result.episodes_processed == 0

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -137,6 +137,7 @@ class TestRunSynthesis:
             storage=mock_storage,
             embedder=mock_embedder,
             user_id="test_user",
+            org_id="test_org",
         )
 
         assert result.semantics_analyzed == 0
@@ -185,6 +186,7 @@ class TestRunSynthesis:
                 storage=mock_storage,
                 embedder=mock_embedder,
                 user_id="test_user",
+                org_id="test_org",
             )
 
         assert result.semantics_analyzed == 2
@@ -233,6 +235,7 @@ class TestRunSynthesis:
                 storage=mock_storage,
                 embedder=mock_embedder,
                 user_id="test_user",
+                org_id="test_org",
             )
 
         assert result.semantics_analyzed == 1
@@ -279,6 +282,7 @@ class TestRunSynthesis:
                 storage=mock_storage,
                 embedder=mock_embedder,
                 user_id="test_user",
+                org_id="test_org",
             )
 
         # Check the procedural was created with deduplicated episode IDs

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -156,7 +156,7 @@ class TestEngramServiceEncode:
 
     @pytest.mark.asyncio
     async def test_encode_high_importance_triggers_consolidation(self, mock_service):
-        """Should trigger consolidation when importance >= threshold."""
+        """Should trigger consolidation when importance >= threshold and org_id is set."""
         from engram.workflows.consolidation import ConsolidationResult
 
         # Configure workflow_backend.run_consolidation to return proper result
@@ -172,6 +172,7 @@ class TestEngramServiceEncode:
             content="Critical information",
             role="user",
             user_id="user_123",
+            org_id="test_org",
             importance=0.9,  # Above threshold (default is 0.8)
         )
 
@@ -202,7 +203,7 @@ class TestEngramServiceEncode:
 
     @pytest.mark.asyncio
     async def test_encode_at_threshold_triggers_consolidation(self, mock_service):
-        """Should trigger consolidation when importance == threshold."""
+        """Should trigger consolidation when importance == threshold and org_id is set."""
         from engram.workflows.consolidation import ConsolidationResult
 
         # Configure workflow_backend.run_consolidation to return proper result
@@ -218,6 +219,7 @@ class TestEngramServiceEncode:
             content="Important information",
             role="user",
             user_id="user_123",
+            org_id="test_org",
             importance=0.8,  # Exactly at threshold (default is 0.8)
         )
 
@@ -236,6 +238,7 @@ class TestEngramServiceEncode:
             content="Critical information",
             role="user",
             user_id="user_123",
+            org_id="test_org",
             importance=0.9,  # Above threshold (default is 0.8)
         )
 


### PR DESCRIPTION
## Summary

- Consolidation, promotion, and decay workflows now **require** `org_id` to scope operations to a single project
- Prevents cross-project memory bleed where semantic memories from unrelated projects could be synthesized together
- MCP tools return a clear error when `org_id` cannot be auto-detected
- High-importance auto-consolidation during `encode()` gracefully skips when `org_id` is not available

## What changed

**Core signatures** (`str | None` → `str`):
- `EngramService.consolidate(user_id, org_id)` 
- `EngramService.create_procedural(user_id, org_id)`
- `WorkflowBackend` protocol + all 3 implementations (InProcess, DBOS, Prefect)
- `run_consolidation()`, `run_consolidation_from_structured()`, `run_synthesis()`, `run_decay()`

**API**:
- `WorkflowTriggerRequest.org_id` is now required (`min_length=1`) — affects `/workflows/consolidate`, `/workflows/decay`, `/workflows/promote`, `/workflows/structure/batch`

**MCP**:
- `engram_consolidate` and `engram_promote` return an error JSON when `org_id` cannot be auto-detected from git remote or `ENGRAM_ORG` env var

**Encode path**:
- `_trigger_consolidation()` skips with a debug log when `org_id` is None, rather than running unscoped consolidation

## Test plan

- [x] 991 tests pass (0 failures)
- [x] mypy strict: 0 errors across 81 source files
- [x] ruff lint + format: clean
- [x] All pre-commit hooks pass